### PR TITLE
Bump `MachOKit` to 0.34.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "be5170ca5b51896a250ad39f95a5369cff2eaa6c88c736178a3ee1891f1f59be",
+  "originHash" : "d62d5232caf5dd9a2098e4715f7c4926c9d04c348f96a237d50043367932429a",
   "pins" : [
     {
       "identity" : "associatedobject",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/p-x9/MachOKit.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "064dd49dda8ceeeae5857782bcd5037e34fc2e19"
+        "revision" : "753461938fafdcdbcd19b68b34b137dc37367d22",
+        "version" : "0.34.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,11 +17,11 @@ extension Package.Dependency {
 
     static let MachOKitMain = Package.Dependency.package(
         url: "https://github.com/p-x9/MachOKit.git",
-        branch: "main"
+        from: "0.34.0"
     )
     static let MachOKitSPM = Package.Dependency.package(
         url: "https://github.com/p-x9/MachOKit-SPM",
-        from: "0.33.0"
+        from: "0.34.0"
     )
 //    static let MachOKitSPM = Package.Dependency.package(
 //        path: "/Volumes/Repositories/Private/Fork/Library/MachOKit-SPM"
@@ -80,6 +80,7 @@ let package = Package(
         .MachOKit,
         .package(url: "https://github.com/swiftlang/swift-syntax", from: "601.0.1"),
         .package(url: "https://github.com/MxIris-Library-Forks/AssociatedObject", branch: "main"),
+        .package(url: "https://github.com/p-x9/swift-fileio", from: "0.9.0"),
     ],
     targets: [
         .target(
@@ -89,6 +90,7 @@ let package = Package(
                 "MachOSwiftSectionMacro",
                 .MachOKit,
                 .product(name: "AssociatedObject", package: "AssociatedObject"),
+                .product(name: "FileIO", package: "swift-fileio"),
             ]
         ),
         .target(

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # MachOSwiftSection
 
-> [!NOTE]
-> The dyld subCache parsing error is a known issues. please switch to `MachOKit`'s main branch as a temporary workaround.
-> https://github.com/p-x9/MachOKit/commit/064dd49dda8ceeeae5857782bcd5037e34fc2e19
-
 A Swift library for parsing mach-o files to obtain Swift information.
 （Types/Protocol/ProtocolConformance info）
 

--- a/Sources/MachOSwiftSection/Extensions/DyldCache+.swift
+++ b/Sources/MachOSwiftSection/Extensions/DyldCache+.swift
@@ -1,13 +1,14 @@
 import Foundation
 import MachOKit
+import FileIO
 
 extension DyldCache {
     var fileHandle: FileHandle {
         try! .init(forReadingFrom: url)
     }
     
-    var fileIO: File {
-        try! File.open(url: url, isWritable: false)
+    var fileIO: MemoryMappedFile {
+        try! .open(url: url, isWritable: false)
     }
 
     var fileStartOffset: UInt64 {

--- a/Sources/MachOSwiftSection/Extensions/MachOFile+.swift
+++ b/Sources/MachOSwiftSection/Extensions/MachOFile+.swift
@@ -8,7 +8,7 @@ extension MachOFile {
     }
 
     var fileIO: MemoryMappedFile {
-        try! File.open(
+        try! .open(
             url: url,
             isWritable: false
         )


### PR DESCRIPTION
- https://github.com/p-x9/MachOKit/releases/tag/0.34.0

The new version resolves a bug related to rebasing the dyld cache and fixes the FileIO library used internally for reading and writing files so that it is not exposed to the interface.

- https://github.com/p-x9/MachOKit/pull/206
- https://github.com/p-x9/MachOKit/pull/207