### PR TITLE
Fix: remove hardcoded base address offset in fallback calculation

### DIFF
--- a/Sources/MachOExtensions/MachORepresentableWithCache.swift
+++ b/Sources/MachOExtensions/MachORepresentableWithCache.swift
@@ -81,7 +81,7 @@ extension MachORepresentableWithCache {
         } else if let cache {
             return .init(cache.mainCacheHeader.sharedRegionStart.cast() + offset)
         } else {
-            return 0x1_0000_0000 + UInt64(offset)
+            return UInt64(offset)
         }
     }
 


### PR DESCRIPTION
## Summary
- Remove the hardcoded `0x1_0000_0000` offset in the fallback address calculation when neither machO header nor cache is available
- Returns the raw offset directly instead of adding an arbitrary base address

## Test plan
- [ ] Verify address resolution works correctly for binaries without cache headers
- [ ] Run existing test suite to confirm no regressions