### PR TITLE
fix: add __TEXT segment base address to offset resolution fallback

### DIFF
--- a/Sources/MachOExtensions/MachORepresentableWithCache.swift
+++ b/Sources/MachOExtensions/MachORepresentableWithCache.swift
@@ -81,7 +81,7 @@ extension MachORepresentableWithCache {
         } else if let cache {
             return .init(cache.mainCacheHeader.sharedRegionStart.cast() + offset)
         } else {
-            return UInt64(offset)
+            return ((loadCommands.text64?.virtualMemoryAddress ?? loadCommands.text?.virtualMemoryAddress) ?? 0).uint64 + UInt64(offset)
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix offset resolution when no MachO image or dyld shared cache is available by adding the `__TEXT` segment base address to the raw offset
- Previously the fallback path returned the raw offset directly, which produced incorrect virtual addresses for non-zero-based binaries

## Test plan
- [ ] Verify offset resolution returns correct addresses for Mach-O files without cache
- [ ] Run `swift test` to ensure no regressions