### PR TITLE
fix: resolve Homebrew release build failures

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -205,7 +205,7 @@ extension Package.Dependency {
         ),
         remote: .package(
             url: "https://github.com/MxIris-Reverse-Engineering/swift-semantic-string",
-            from: "0.1.0"
+            exact: "0.1.0"
         )
     )
 }

--- a/Sources/MachOTestingSupport/DumpableTests.swift
+++ b/Sources/MachOTestingSupport/DumpableTests.swift
@@ -5,7 +5,7 @@ import MachOSwiftSection
 import SwiftDump
 import Dependencies
 @_spi(Internals) import MachOSymbols
-@testable import SwiftInspection
+import SwiftInspection
 
 @MainActor
 package protocol DumpableTests {


### PR DESCRIPTION
## Summary
- Remove unnecessary `@testable` from `SwiftInspection` import in `MachOTestingSupport` (fixes release mode build failure)
- Pin `swift-semantic-string` to `exact: "0.1.0"` to prevent breaking changes from 0.1.1

## Context
Homebrew PR https://github.com/Homebrew/homebrew-core/pull/273507 failed to build 0.8.1 because:
1. `@testable import SwiftInspection` fails in `-c release` mode
2. `swift-semantic-string` 0.1.1 removed `OffsetComment`/`AddressComment`/`ImportsBlock` types

Tagged as `0.8.2` for Homebrew release.