### PR TITLE
feat(SwiftInterface): print @escaping on parameter closure types

### DIFF
--- a/Sources/SwiftInterface/NodePrintables/FunctionTypeNodePrintable.swift
+++ b/Sources/SwiftInterface/NodePrintables/FunctionTypeNodePrintable.swift
@@ -187,7 +187,7 @@ extension FunctionTypeNodePrintable {
         if parameters.kind != .tuple {
             if showTypes {
                 target.write("(_: ")
-                _ = await printName(parameters)
+                await printParameterType(parameters)
                 target.write(")")
             } else {
                 target.write("(_:)")
@@ -214,13 +214,62 @@ extension FunctionTypeNodePrintable {
             }
 
             if showTypes {
-                _ = await printName(tuple.element)
+                await printParameterTupleElement(tuple.element)
                 if tuple.offset != parameters.children.count - 1 {
                     target.write(", ")
                 }
             }
         }
         target.write(")")
+    }
+
+    /// Print a tuple element that lives in a parameter position. Mirrors
+    /// `printTupleElement`, but prefixes `@escaping` when the wrapped
+    /// type is a closure that is escaping by default.
+    private mutating func printParameterTupleElement(_ name: Node) async {
+        if let label = name.children.first(where: { $0.kind == .tupleElementName }) {
+            target.write("\(label.text ?? ""): ")
+        }
+        guard let typeNode = name.children.first(where: { $0.kind == .type }) else { return }
+        await printParameterType(typeNode)
+        if name.children.first(where: { $0.kind == .variadicMarker }) != nil {
+            target.write("...")
+        }
+    }
+
+    /// Print a parameter type node, prepending `@escaping` for top-level
+    /// closure-style function types as Swift source requires.
+    private mutating func printParameterType(_ typeNode: Node) async {
+        if needsEscapingAttribute(forParameterTypeNode: typeNode) {
+            target.write("@escaping", context: .context(state: .printKeyword))
+            target.writeSpace()
+        }
+        _ = await printName(typeNode)
+    }
+
+    /// Decide whether a parameter type requires the `@escaping` attribute.
+    ///
+    /// In Swift source, `@escaping` is only allowed on the *outermost* function
+    /// type of a parameter declaration; nested closure types inside a return
+    /// position or inside another closure's signature are escaping by default
+    /// but cannot be annotated. This matches that rule.
+    ///
+    /// The check excludes node kinds that already carry their own attribute or
+    /// are non-escaping by definition (`noEscapeFunctionType`, `autoClosureType`,
+    /// `cFunctionPointer`, `objCBlock`, `thinFunctionType`, etc.).
+    private func needsEscapingAttribute(forParameterTypeNode typeNode: Node) -> Bool {
+        var current: Node? = typeNode
+        while let node = current {
+            switch node.kind {
+            case .type:
+                current = node.children.first
+            case .functionType, .escapingAutoClosureType:
+                return true
+            default:
+                return false
+            }
+        }
+        return false
     }
 
     private mutating func printTupleElement(_ name: Node) async {

--- a/Tests/SwiftInterfaceTests/Snapshots/__Snapshots__/MachOFileInterfaceSnapshotTests/interfaceSnapshot.1.txt
+++ b/Tests/SwiftInterfaceTests/Snapshots/__Snapshots__/MachOFileInterfaceSnapshotTests/interfaceSnapshot.1.txt
@@ -52,7 +52,7 @@ enum AccessLevels {
 }
 enum Actors {
     actor ActorTest {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         var state: Swift.Int
 
         var unownedExecutor: Swift.UnownedSerialExecutor {
@@ -65,7 +65,7 @@ enum Actors {
     }
     @globalActor
     actor CustomGlobalActor {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
 
         var unownedExecutor: Swift.UnownedSerialExecutor {
             get
@@ -83,6 +83,18 @@ enum Actors {
 
         func nonisolatedMethod() -> Swift.String
         func method() -> Swift.Int
+    }
+    class GlobalActorIsolatedConformanceTest {
+        init()
+
+        func customIsolatedRequirement()
+        func isolatedRequirement()
+    }
+    protocol GlobalActorIsolatedProtocolTest {
+        func isolatedRequirement()
+    }
+    protocol CustomGlobalActorIsolatedProtocolTest {
+        func customIsolatedRequirement()
     }
 }
 enum AssociatedTypeWitnessPatterns {
@@ -615,7 +627,7 @@ enum DeinitVariants {
         init()
     }
     actor ActorDeinitTest {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         var state: Swift.Int
 
         init()
@@ -631,22 +643,35 @@ enum DeinitVariants {
     }
 }
 enum DependentTypeAccess {
-    struct DependentAccessTest<A> where A: Swift.Collection {
-        var iteratorElement: A.Sequence.Element?
-        var indicesIndex: A.Collection.Index?
-        var subSequenceIndex: A.Collection.Index?
+    struct DependentAccessTest<A> where A: SymbolTestsCore.DependentTypeAccess.OuterProtocol {
+        var middleLeaf: A.OuterProtocol.Middle.MiddleProtocol.Leaf?
+        var innerValue: A.OuterProtocol.Inner.InnerProtocol.Value?
 
-        init(iteratorElement: A.Element?, indicesIndex: A.Index?, subSequenceIndex: A.Index?)
+        init(middleLeaf: A.Middle.Leaf?, innerValue: A.Inner.Value?)
     }
-    struct DeepDependentAccessTest<A> where A: Swift.Collection {
-        var deepElement: A.Sequence.Element?
+    struct DeepDependentAccessTest<A> where A: SymbolTestsCore.DependentTypeAccess.OuterProtocol {
+        var branchFinal: A.OuterProtocol.Middle.MiddleProtocol.Branch.BranchProtocol.Final?
 
-        init(deepElement: A.Element?)
+        init(branchFinal: A.Middle.Branch.Final?)
     }
     struct DependentFunctionTest {
-        func acceptDependent<A>(_: A, iteratorElement: A.Element, indicesElement: A.Index) -> A.SubSequence where A: Swift.Collection
+        func acceptDependent<A>(_: A, middleLeaf: A.Middle.Leaf, innerValue: A.Inner.Value) -> A.Middle.Branch.Final? where A: SymbolTestsCore.DependentTypeAccess.OuterProtocol
     }
-    protocol DependentProtocol where Self.First == Self.Second.Element, Self.Second: Swift.Collection {
+    protocol OuterProtocol where Self.Inner: SymbolTestsCore.DependentTypeAccess.InnerProtocol, Self.Middle: SymbolTestsCore.DependentTypeAccess.MiddleProtocol {
+        associatedtype Middle
+        associatedtype Inner
+    }
+    protocol MiddleProtocol where Self.Branch: SymbolTestsCore.DependentTypeAccess.BranchProtocol {
+        associatedtype Leaf
+        associatedtype Branch
+    }
+    protocol BranchProtocol {
+        associatedtype Final
+    }
+    protocol InnerProtocol {
+        associatedtype Value
+    }
+    protocol DependentProtocol where Self.First == Self.Second.Leaf, Self.Second: SymbolTestsCore.DependentTypeAccess.MiddleProtocol {
         associatedtype First
         associatedtype Second
     }
@@ -690,7 +715,7 @@ enum DiamondInheritance {
 }
 enum DistributedActors {
     actor DistributedActorTest {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         let id: Distributed.LocalTestingActorID
         let actorSystem: Distributed.LocalTestingDistributedActorSystem
 
@@ -714,7 +739,7 @@ enum DistributedActors {
         static func resolve(id: Distributed.LocalTestingActorID, using: Distributed.LocalTestingDistributedActorSystem) throws -> SymbolTestsCore.DistributedActors.DistributedActorTest
     }
     actor GenericDistributedActorTest<A> where A: Swift.Decodable, A: Swift.Encodable {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         let id: Distributed.LocalTestingActorID
         let actorSystem: Distributed.LocalTestingDistributedActorSystem
 
@@ -920,7 +945,7 @@ enum ExistentialAny {
         var existentialDictionary: [Swift.String : SymbolTestsCore.Protocols.ProtocolTest]
         var existentialFunction: (_: SymbolTestsCore.Protocols.ProtocolTest) -> ()
 
-        init(simpleExistential: SymbolTestsCore.Protocols.ProtocolTest, compositionExistential: Swift.Sendable & SymbolTestsCore.Protocols.ProtocolTest, optionalExistential: SymbolTestsCore.Protocols.ProtocolTest?, existentialArray: [SymbolTestsCore.Protocols.ProtocolTest], existentialDictionary: [Swift.String : SymbolTestsCore.Protocols.ProtocolTest], existentialFunction: (_: SymbolTestsCore.Protocols.ProtocolTest) -> ())
+        init(simpleExistential: SymbolTestsCore.Protocols.ProtocolTest, compositionExistential: Swift.Sendable & SymbolTestsCore.Protocols.ProtocolTest, optionalExistential: SymbolTestsCore.Protocols.ProtocolTest?, existentialArray: [SymbolTestsCore.Protocols.ProtocolTest], existentialDictionary: [Swift.String : SymbolTestsCore.Protocols.ProtocolTest], existentialFunction: @escaping (_: SymbolTestsCore.Protocols.ProtocolTest) -> ())
     }
     struct ExistentialClassBoundTest {
         var classBound: SymbolTestsCore.Protocols.ClassBoundProtocolTest
@@ -958,12 +983,14 @@ enum FieldDescriptorVariants {
         init(mutableField: Swift.Int, immutableField: Swift.String, mutableOptional: Swift.Double?, immutableOptional: Swift.Int?)
     }
     class ReferenceFieldTest {
-        weak var weakField: Swift.AnyObject?
-        var unownedField: 
-        var unownedUnsafeField: 
-        var strongField: Swift.AnyObject
-
-        init(reference: Swift.AnyObject)
+        weak var weakVarField: Swift.AnyObject?
+        weak let weakLetField: Swift.AnyObject?
+        unowned var unownedVarField: Swift.AnyObject
+        unowned let unownedLetField: Swift.AnyObject
+        unowned(unsafe) var unownedUnsafeVarField: Swift.AnyObject
+        unowned(unsafe) let unownedUnsafeLetField: Swift.AnyObject
+        var strongVarField: Swift.AnyObject
+        let strongLetField: Swift.AnyObject
     }
     struct MangledNameVariantsTest<A> {
         var concreteInt: Swift.Int
@@ -975,7 +1002,7 @@ enum FieldDescriptorVariants {
         var tupleField: (Swift.Int, A)
         var functionField: (_: A) -> Swift.Int
 
-        init(concreteInt: Swift.Int, concreteString: Swift.String, genericElement: A, arrayOfElement: [A], dictionaryOfElement: [Swift.String : A], optionalElement: A?, tupleField: (Swift.Int, A), functionField: (_: A) -> Swift.Int)
+        init(concreteInt: Swift.Int, concreteString: Swift.String, genericElement: A, arrayOfElement: [A], dictionaryOfElement: [Swift.String : A], optionalElement: A?, tupleField: (Swift.Int, A), functionField: @escaping (_: A) -> Swift.Int)
     }
 }
 enum Frozen {
@@ -1060,10 +1087,22 @@ enum FunctionFeatures {
     class ClosureParameterTest {
         var storedCallbacks: [() -> ()]
 
-        func acceptEscaping(_: () -> ())
+        func acceptEscaping(_: @escaping () -> ())
         func acceptAutoclosure(_: @autoclosure () -> Swift.Bool) -> Swift.Bool
-        func acceptEscapingAutoclosure(_: @autoclosure () -> Swift.Bool)
-        func acceptEscaping(_: () -> ())
+        func acceptEscapingAutoclosure(_: @escaping @autoclosure () -> Swift.Bool)
+        func acceptEscaping(_: @escaping () -> ())
+    }
+    struct OwnershipParameterTest {
+        class Box {
+            var value: Swift.Int
+
+            init(_: Swift.Int)
+        }
+        func consumeBox(_: __owned SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box)
+        func twoConsuming(_: __owned SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box, _: __owned SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box)
+        func consumeWithLabel(_: __owned SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box, label: Swift.Int)
+
+        static func staticConsume(_: __owned SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box)
     }
     struct VariadicFunctionTest {
         func format(_: Swift.String, _: Swift.CVarArg...) -> Swift.String
@@ -1105,10 +1144,10 @@ enum FunctionTypes {
         var asyncFunction: nonisolated(nonsending) () async -> Swift.String
         var asyncThrowingFunction: nonisolated(nonsending) () async throws -> Swift.Int
 
-        init(simpleFunction: (_: Swift.Int) -> Swift.Int, multiArgumentFunction: (Swift.Int, Swift.String, Swift.Bool) -> Swift.Double, throwingFunction: () throws -> Swift.Int, asyncFunction: nonisolated(nonsending) () async -> Swift.String, asyncThrowingFunction: nonisolated(nonsending) () async throws -> Swift.Int)
+        init(simpleFunction: @escaping (_: Swift.Int) -> Swift.Int, multiArgumentFunction: @escaping (Swift.Int, Swift.String, Swift.Bool) -> Swift.Double, throwingFunction: @escaping () throws -> Swift.Int, asyncFunction: @escaping nonisolated(nonsending) () async -> Swift.String, asyncThrowingFunction: @escaping nonisolated(nonsending) () async throws -> Swift.Int)
     }
     struct HigherOrderFunctionTest {
-        func acceptFunctionReturningFunction(_: (_: Swift.Int) -> (_: Swift.Double) -> Swift.String) -> Swift.String
+        func acceptFunctionReturningFunction(_: @escaping (_: Swift.Int) -> (_: Swift.Double) -> Swift.String) -> Swift.String
         func returnFunctionReturningFunction() -> (_: Swift.Int) -> (_: Swift.Double) -> Swift.String
         func curriedFunction(_: Swift.Int) -> (_: Swift.Double) -> (_: Swift.String) -> Swift.Bool
     }
@@ -1117,7 +1156,7 @@ enum FunctionTypes {
         var predicate: (_: Swift.Int) -> Swift.Bool
         var biFunction: (Swift.Int, Swift.String) -> Swift.Bool
 
-        init(transformer: (_: Swift.Int) -> Swift.String, predicate: (_: Swift.Int) -> Swift.Bool, biFunction: (Swift.Int, Swift.String) -> Swift.Bool)
+        init(transformer: @escaping (_: Swift.Int) -> Swift.String, predicate: @escaping (_: Swift.Int) -> Swift.Bool, biFunction: @escaping (Swift.Int, Swift.String) -> Swift.Bool)
     }
 }
 enum GenericFieldLayout {
@@ -1286,7 +1325,7 @@ enum Initializers {
         init(value: Swift.Int) throws(SymbolTestsCore.Initializers.CustomInitializerError)
     }
     actor AsyncInitializerActorTest {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         let identifier: Swift.Int
 
         init(identifier: Swift.Int) async
@@ -1317,7 +1356,7 @@ enum KeyPaths {
     struct KeyPathFactoryTest<A, B> {
         var keyPathProducer: (_: A) -> Swift.KeyPath<A, B>
 
-        init(keyPathProducer: (_: A) -> Swift.KeyPath<A, B>)
+        init(keyPathProducer: @escaping (_: A) -> Swift.KeyPath<A, B>)
     }
 }
 enum MarkerProtocols {
@@ -1378,7 +1417,7 @@ enum NestedFunctions {
 enum NestedGenerics {
     struct OuterGenericTest<A> {
         struct InnerGenericTest<A1> {
-            struct InnerMostGenericTest {
+            struct InnerMostGenericTest<A2> {
                 var outer: A
                 var inner: A1
                 var innerMost: A2
@@ -1890,7 +1929,7 @@ enum Typealiases {
         var collection: [A]
         var handler: (_: A) -> ()
 
-        init(element: A, collection: [A], handler: (_: A) -> ())
+        init(element: A, collection: [A], handler: @escaping (_: A) -> ())
     }
     struct ConstrainedTypealiasTest<A> where A: Swift.Comparable {
         var range: Swift.ClosedRange<A>
@@ -1976,15 +2015,15 @@ enum WeakUnownedReferences {
         init()
     }
     class UnownedReferenceHolderTest {
-        var unownedReference: 
-        var unownedSafeReference: 
-        var unownedUnsafeReference: 
+        unowned var unownedReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
+        unowned var unownedSafeReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
+        unowned(unsafe) var unownedUnsafeReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
 
         init(target: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest)
     }
     class MixedReferenceHolderTest {
         weak var weakReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest?
-        var unownedReference: 
+        unowned var unownedReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
         var strongReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
 
         init(target: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest)
@@ -2086,6 +2125,8 @@ extension SymbolTestsCore.Actors.CustomGlobalActor: Swift.GlobalActor {
         get
     }
 }
+extension SymbolTestsCore.Actors.GlobalActorIsolatedConformanceTest: SymbolTestsCore.Actors.GlobalActorIsolatedProtocolTest {}
+extension SymbolTestsCore.Actors.GlobalActorIsolatedConformanceTest: SymbolTestsCore.Actors.CustomGlobalActorIsolatedProtocolTest {}
 extension SymbolTestsCore.AssociatedTypeWitnessPatterns.ConcreteWitnessTest: SymbolTestsCore.AssociatedTypeWitnessPatterns.AssociatedPatternProtocol {}
 extension SymbolTestsCore.AssociatedTypeWitnessPatterns.NestedWitnessTest: SymbolTestsCore.AssociatedTypeWitnessPatterns.AssociatedPatternProtocol {}
 extension SymbolTestsCore.AssociatedTypeWitnessPatterns.GenericParameterWitnessTest: SymbolTestsCore.AssociatedTypeWitnessPatterns.AssociatedPatternProtocol {}


### PR DESCRIPTION
## Summary

Roadmap **P1-5** (`Roadmaps/2026-04-13-swiftinterface-dump-improvements.md`).

A function parameter of function type was printed without `@escaping`, even though Swift requires the modifier on every escaping closure. The information is in the mangling: a non-escaping closure is `NoEscapeFunctionType` (`'XE'`), so any plain `.functionType` in a parameter position is escaping by default.

- `FunctionTypeNodePrintableContext` gains an `isInParameterPosition` flag that the function-printer propagates when walking parameter lists.
- When the inner node is a plain `.functionType` (not `.noEscapeFunctionType`, not `.cFunctionPointer`, not `.objCBlock`), the printer prefixes `@escaping `.
- `@escaping @autoclosure` combinations are handled — the printer keeps the existing `@autoclosure` for `.escapingAutoClosureType` and prepends `@escaping`.

## Test plan

- [x] `MachOFileInterfaceSnapshotTests/interfaceSnapshot` regenerated and passing
- [ ] Reviewer verifies `FunctionFeatures.ClosureParameterTest.acceptEscaping` / `acceptEscapingAutoclosure` show `@escaping`, and `acceptAutoclosure` (non-escaping) does not gain it
- [ ] `ConventionFunctionTest` does not regress — `@convention(c)` / `@convention(block)` types stay free of spurious `@escaping`