### PR TITLE
feat(SwiftInterface): print consuming/borrowing parameter modifiers

### DIFF
--- a/Roadmaps/2026-04-13-swiftinterface-dump-improvements.md
+++ b/Roadmaps/2026-04-13-swiftinterface-dump-improvements.md
@@ -123,42 +123,85 @@ which is ~100 characters of protocol repetition.
 
 ---
 
-### P1-7. `consuming` parameter modifier
+### P1-7. `consuming` / `borrowing` parameter modifier
 
-**Symptom.** `public init(value: consuming T)` and similar consuming parameter declarations lose the `consuming` keyword in the dump.
+**Symptom.** Parameters declared with `consuming` (or `borrowing`) lose the
+keyword in the dump and print as a bare type. `__owned` / `__shared` (the
+demangler-level spellings) are wrong for a Swift source-facing interface
+file — Swift 5.9+ writes `consuming` / `borrowing` at source level.
 
-**Source fixture.** `Tests/Projects/SymbolTests/SymbolTestsCore/Noncopyable.swift`
+**Source fixture.** No project-local fixture is needed: SymbolTestsCore
+already conforms `OptionSetAndRawRepresentable.OptionSetTest` to
+`Swift.SetAlgebra`, whose protocol witnesses carry the `n` (owned)
+parameter convention. Examples picked up from the fixture binary:
+- `func union(_: consuming Self) -> Self`
+- `func symmetricDifference(_: consuming Self) -> Self`
+- `func insert(_: consuming Self.Element) -> ...`
+- `func update(with: consuming Self.Element) -> Self.Element?`
+- `func formUnion(_: consuming Self)`
+- `init<A1>(_: consuming A1) where A1: Swift.Sequence, ...`
+
+**Current dump (before fix).**
 ```swift
-public struct NoncopyableGenericTest<T: ~Copyable>: ~Copyable {
-    public let value: T
-    public init(value: consuming T) { self.value = value }
-}
-```
-
-**Current dump.**
-```swift
-init(element: A)   // consuming missing
+func union(_: __owned Self) -> Self
+func insert(_: __owned Self.Element) -> ...
+init<A1>(_: __owned A1) where A1: Swift.Sequence, ...
 ```
 
 **Evidence the information is present.**
-- `swift/docs/ABI/Mangling.rst:783` — the `list-type` production allows per-parameter ownership convention flags: `'n'` (owned/consuming), `'k'` (inout), `'h'` (shared), `'g'` (guaranteed), etc. These are source-level, not SIL-only.
-- `swift-demangling/Sources/Demangling/Main/Demangle/Demangler.swift:1194-1200` — the demangler already handles several of these conventions; extend to cover `'n'` as `Node.Kind.owned` / a new `.consuming` kind.
-- The Swift `NodePrinter` prints these as `__owned`, `__shared`, etc. Swift 5.9+ renamed to `consuming` / `borrowing` at source level — the `__owned`/`__shared` are the AST-level internal names.
+- `swift/docs/ABI/Mangling.rst:783` — the `list-type` production allows
+  per-parameter ownership convention flags: `'n'` (owned/consuming),
+  `'h'` (shared/borrowing), `'k'` (inout), `'g'` (guaranteed), etc.
+- `swift-demangling/Sources/Demangling/Main/Demangle/Demangler.swift:226,230`
+  — the demangler already handles `'h'` → `.shared` and `'n'` → `.owned`.
+  No demangler change needed.
+- `Sources/SwiftInterface/NodePrintables/NodePrintable.swift:37-38`
+  already had a `.owned → "__owned "` branch but no `.shared` branch.
+
+**ABI limitation — `init` parameter modifiers are not recoverable.**
+The Swift compiler does **not** emit the `n` / `h` flag in mangled
+constructor symbols. Verified empirically with `swiftc` + `nm` +
+`xcrun swift-demangle`:
+
+| Declaration | mangled `n`? | demangle tree has `.owned`? |
+|---|---|---|
+| `func single(_ box: consuming Box)` | yes | yes |
+| `func twoParams(_ box: consuming Box, label: Int)` | yes | yes |
+| `S.methodSingle(_ box: consuming Box)` | yes | yes |
+| `S.init(box: consuming Box)` | **no** | **no** |
+| `S.init(box: consuming Box, label: Int)` | **no** | **no** |
+
+Concretely, `NoncopyableGenericTest.init(value: consuming T)` mangles to
+`_$s15SymbolTestsCore11NoncopyableO0D11GenericTestVAARi_zrlE5valueAEy_xGx_tcfC`,
+whose demangle tree's `ArgumentTuple → Tuple → TupleElement → Type` is a
+bare `DependentGenericParamType` with no `.owned` wrapper. For
+`~Copyable` types in particular, by-value parameters are implicitly
+consuming (a noncopyable value cannot be copied), so the compiler treats
+the keyword as the default and never mangles it — there is nothing in
+the binary to recover.
 
 **Modification points.**
-1. `swift-demangling/Sources/Demangling/Main/Demangle/Demangler.swift` near line 1194 — audit which parameter convention characters are currently handled; add any missing cases.
-2. `swift-demangling/Sources/Demangling/Node/Printer/NodePrinter.swift` — already handles `.owned` node as `__owned` (see line referenced in `NodePrintable.swift:37-38`). Swift source convention is `consuming` (not `__owned`) for the source-level parameter modifier. Decide whether to:
-   - Add a new option `preferSourceOwnershipSpelling` that maps `__owned` → `consuming` / `__shared` → `borrowing`, or
-   - Unconditionally use the source-level spelling in `InterfaceNodePrintable`.
-3. `Sources/SwiftInterface/NodePrintables/FunctionTypeNodePrintable.swift` — ensure parameter printing goes through the convention-aware path and emits the keyword before the type.
+1. `Sources/SwiftInterface/NodePrintables/NodePrintable.swift` — change
+   the `.owned` branch's prefix from `"__owned "` to `"consuming "`,
+   and add a new `.shared` branch with prefix `"borrowing "`. The
+   demangler dependency is unchanged: SwiftInterface is the
+   source-facing layer, swift-demangling continues to print
+   `__owned` / `__shared` for general-purpose use.
 
 **Verification.**
-- `NoncopyableGenericTest.init(value:)` must print `init(element: consuming A)`.
-- Cross-check: `FunctionFeatures.InoutFunctionTest.swap/modify` uses `inout` parameters. Their dump currently prints `inout Swift.Int` (correct). Do not regress.
+- `OptionSetTest`'s SetAlgebra witnesses (above) print `consuming`
+  instead of `__owned`. (The full dump `grep -c "__owned\|__shared"`
+  must return 0.)
+- `FunctionFeatures.InoutFunctionTest.swap/modify` continue to print
+  `inout Swift.Int` — `inout` is a separate node kind (`.inOut`) and
+  is unaffected.
+- `NoncopyableGenericTest.init(value:)` continues to print without
+  `consuming` — see the ABI limitation above. Do **not** treat this as
+  a bug.
 
-**Risk.** Low. Parameter convention parsing is well-understood.
+**Risk.** Low. The change is one switch case + one new switch case.
 
-**Effort.** Small-medium (half to one day). Depends on whether `swift-demangling` needs new demangling cases or just printer changes.
+**Effort.** Small (~1 hour). No demangler dependency change needed.
 
 ---
 

--- a/Roadmaps/2026-04-13-swiftinterface-dump-improvements.md
+++ b/Roadmaps/2026-04-13-swiftinterface-dump-improvements.md
@@ -130,10 +130,12 @@ keyword in the dump and print as a bare type. `__owned` / `__shared` (the
 demangler-level spellings) are wrong for a Swift source-facing interface
 file — Swift 5.9+ writes `consuming` / `borrowing` at source level.
 
-**Source fixture.** No project-local fixture is needed: SymbolTestsCore
-already conforms `OptionSetAndRawRepresentable.OptionSetTest` to
-`Swift.SetAlgebra`, whose protocol witnesses carry the `n` (owned)
-parameter convention. Examples picked up from the fixture binary:
+**Source fixture.** `Tests/Projects/SymbolTests/SymbolTestsCore/FunctionFeatures.swift`
+provides `FunctionFeatures.OwnershipParameterTest` with method-level
+`consuming` parameters (single, multi, with-label, static). In addition,
+`OptionSetAndRawRepresentable.OptionSetTest`'s `Swift.SetAlgebra`
+protocol witnesses carry `__owned`-mangled parameters from the stdlib
+side and exercise the same node-printer path:
 - `func union(_: consuming Self) -> Self`
 - `func symmetricDifference(_: consuming Self) -> Self`
 - `func insert(_: consuming Self.Element) -> ...`
@@ -150,16 +152,16 @@ init<A1>(_: __owned A1) where A1: Swift.Sequence, ...
 
 **Evidence the information is present.**
 - `swift/docs/ABI/Mangling.rst:783` — the `list-type` production allows
-  per-parameter ownership convention flags: `'n'` (owned/consuming),
-  `'h'` (shared/borrowing), `'k'` (inout), `'g'` (guaranteed), etc.
+  per-parameter ownership convention flags: `'n'` (owned), `'h'`
+  (shared), `'k'` (inout), `'g'` (guaranteed), etc.
 - `swift-demangling/Sources/Demangling/Main/Demangle/Demangler.swift:226,230`
   — the demangler already handles `'h'` → `.shared` and `'n'` → `.owned`.
   No demangler change needed.
 - `Sources/SwiftInterface/NodePrintables/NodePrintable.swift:37-38`
   already had a `.owned → "__owned "` branch but no `.shared` branch.
 
-**ABI limitation — `init` parameter modifiers are not recoverable.**
-The Swift compiler does **not** emit the `n` / `h` flag in mangled
+**ABI limitation 1 — `init` parameter modifiers are not recoverable.**
+The Swift compiler does **not** emit the `n` flag in mangled
 constructor symbols. Verified empirically with `swiftc` + `nm` +
 `xcrun swift-demangle`:
 
@@ -177,8 +179,22 @@ whose demangle tree's `ArgumentTuple → Tuple → TupleElement → Type` is a
 bare `DependentGenericParamType` with no `.owned` wrapper. For
 `~Copyable` types in particular, by-value parameters are implicitly
 consuming (a noncopyable value cannot be copied), so the compiler treats
-the keyword as the default and never mangles it — there is nothing in
-the binary to recover.
+the keyword as the default and never mangles it.
+
+**ABI limitation 2 — source-level `borrowing` is also not recoverable.**
+The `h` flag in the mangling spec is reachable only from the *legacy*
+`__shared` spelling, **not** from Swift 5.9+'s `borrowing`. Verified
+empirically: a `func b(_ s: borrowing S) -> Int` produces a mangled name
+**byte-identical** to the same function with no ownership modifier
+(`_$s1h1bySiAA1SVF`), while a `func c(_ s: __shared S) -> Int` does
+include the `h` flag (`_$s1h1cySiAA1SVhF`) and demangles back to
+`__shared S`. So the printer's `.shared → "borrowing "` rewrite still
+works, but only for binaries whose source uses the old `__shared`
+spelling — most notably stdlib/Foundation functions like
+`Foundation.String.init(format: __shared String, ...)`. Pure
+`borrowing`-only sources (including `OwnershipParameterTest` if it
+were extended) cannot be verified, because `borrowing` produces no
+node to print.
 
 **Modification points.**
 1. `Sources/SwiftInterface/NodePrintables/NodePrintable.swift` — change
@@ -189,6 +205,9 @@ the binary to recover.
    `__owned` / `__shared` for general-purpose use.
 
 **Verification.**
+- `FunctionFeatures.OwnershipParameterTest.consumeBox(_:)`,
+  `consumeWithLabel(_:label:)`, `twoConsuming(_:_:)`, and the static
+  `staticConsume(_:)` all print `consuming` before the `Box` parameter.
 - `OptionSetTest`'s SetAlgebra witnesses (above) print `consuming`
   instead of `__owned`. (The full dump `grep -c "__owned\|__shared"`
   must return 0.)
@@ -196,8 +215,10 @@ the binary to recover.
   `inout Swift.Int` — `inout` is a separate node kind (`.inOut`) and
   is unaffected.
 - `NoncopyableGenericTest.init(value:)` continues to print without
-  `consuming` — see the ABI limitation above. Do **not** treat this as
-  a bug.
+  `consuming` — see ABI limitation 1. Do **not** treat this as a bug.
+- The `.shared → borrowing` rewrite is verified only via the dyld-cache
+  snapshot tests where Foundation `__shared` parameters appear; not by
+  SymbolTestsCore — see ABI limitation 2.
 
 **Risk.** Low. The change is one switch case + one new switch case.
 

--- a/Sources/SwiftInterface/NodePrintables/NodePrintable.swift
+++ b/Sources/SwiftInterface/NodePrintables/NodePrintable.swift
@@ -35,7 +35,15 @@ extension NodePrintable {
         case .inOut:
             await printFirstChild(name, prefix: "inout ", prefixContext: .context(for: name, state: .printKeyword))
         case .owned:
-            await printFirstChild(name, prefix: "__owned ", prefixContext: .context(for: name, state: .printKeyword))
+            // Swift 5.9+ source-level spelling for the `n` ownership mangling.
+            // The demangler ABI calls this `Owned`; swift-demangling and the
+            // historical Swift NodePrinter both emit `__owned`. We prefer the
+            // source-facing keyword `consuming` here.
+            await printFirstChild(name, prefix: "consuming ", prefixContext: .context(for: name, state: .printKeyword))
+        case .shared:
+            // Source-level spelling for the `h` ownership mangling.
+            // Demangler kind is `Shared`; older spelling is `__shared`.
+            await printFirstChild(name, prefix: "borrowing ", prefixContext: .context(for: name, state: .printKeyword))
         case .isolated:
             await printFirstChild(name, prefix: "isolated ", prefixContext: .context(for: name, state: .printKeyword))
         case .isolatedAnyFunctionType:

--- a/Tests/Projects/SymbolTests/SymbolTestsCore/FunctionFeatures.swift
+++ b/Tests/Projects/SymbolTests/SymbolTestsCore/FunctionFeatures.swift
@@ -35,6 +35,52 @@ public enum FunctionFeatures {
         }
     }
 
+    /// Fixture for the `consuming` parameter modifier path
+    /// (mangling: `n` → demangler `.owned` → printed as `consuming`).
+    ///
+    /// Notes on what this fixture can and cannot cover:
+    ///
+    /// - `consuming` on a free function or method parameter IS mangled
+    ///   (as `n`). All four entries below produce `.owned` nodes in the
+    ///   demangle tree and therefore round-trip through the printer.
+    /// - `borrowing` on a parameter is **never** mangled by the Swift
+    ///   compiler — its mangled name is byte-identical to a parameter
+    ///   with no ownership modifier at all (verified empirically with
+    ///   `swiftc` + `nm` for both class- and struct-typed parameters).
+    ///   So a `borrowing` fixture would produce no `.shared` node and
+    ///   would not exercise the printer path. The `.shared`-printed-as-
+    ///   `borrowing` route is reached only via legacy `__shared`
+    ///   spellings (e.g. `Foundation.String.init(format: __shared
+    ///   String, ...)`), which are already covered by the dyld-cache
+    ///   snapshot tests, not by SymbolTestsCore.
+    /// - `init` parameters do not mangle `consuming` either (see
+    ///   roadmap P1-7 ABI limitation). Hence only methods and a
+    ///   `static` method here.
+    public struct OwnershipParameterTest {
+        public class Box {
+            public var value: Int
+            public init(_ value: Int) { self.value = value }
+        }
+
+        public func consumeBox(_ box: consuming Box) {
+            _ = box
+        }
+
+        public func consumeWithLabel(_ box: consuming Box, label: Int) {
+            _ = box
+            _ = label
+        }
+
+        public func twoConsuming(_ first: consuming Box, _ second: consuming Box) {
+            _ = first
+            _ = second
+        }
+
+        public static func staticConsume(_ box: consuming Box) {
+            _ = box
+        }
+    }
+
     public struct VariadicFunctionTest {
         public func sum(_ values: Int...) -> Int {
             values.reduce(0, +)

--- a/Tests/SwiftInterfaceTests/Snapshots/__Snapshots__/MachOFileInterfaceSnapshotTests/interfaceSnapshot.1.txt
+++ b/Tests/SwiftInterfaceTests/Snapshots/__Snapshots__/MachOFileInterfaceSnapshotTests/interfaceSnapshot.1.txt
@@ -12,7 +12,7 @@ var globalConstant: Swift.Int {
 }
 var globalVariable: Swift.String
 
-func _finalizeUninitializedArray<A>(_: __owned [A]) -> [A]
+func _finalizeUninitializedArray<A>(_: consuming [A]) -> [A]
 func getContiguousArrayStorageType<A>(for: A.Type) -> Swift._ContiguousArrayStorage<A>.Type
 func globalGenericFunction<A>(_: A) -> A.Body where A: SymbolTestsCore.Protocols.ProtocolTest
 func globalThrowingFunction() throws -> Swift.String
@@ -52,7 +52,7 @@ enum AccessLevels {
 }
 enum Actors {
     actor ActorTest {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         var state: Swift.Int
 
         var unownedExecutor: Swift.UnownedSerialExecutor {
@@ -65,7 +65,7 @@ enum Actors {
     }
     @globalActor
     actor CustomGlobalActor {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
 
         var unownedExecutor: Swift.UnownedSerialExecutor {
             get
@@ -83,6 +83,18 @@ enum Actors {
 
         func nonisolatedMethod() -> Swift.String
         func method() -> Swift.Int
+    }
+    class GlobalActorIsolatedConformanceTest {
+        init()
+
+        func customIsolatedRequirement()
+        func isolatedRequirement()
+    }
+    protocol GlobalActorIsolatedProtocolTest {
+        func isolatedRequirement()
+    }
+    protocol CustomGlobalActorIsolatedProtocolTest {
+        func customIsolatedRequirement()
     }
 }
 enum AssociatedTypeWitnessPatterns {
@@ -615,7 +627,7 @@ enum DeinitVariants {
         init()
     }
     actor ActorDeinitTest {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         var state: Swift.Int
 
         init()
@@ -631,22 +643,35 @@ enum DeinitVariants {
     }
 }
 enum DependentTypeAccess {
-    struct DependentAccessTest<A> where A: Swift.Collection {
-        var iteratorElement: A.Sequence.Element?
-        var indicesIndex: A.Collection.Index?
-        var subSequenceIndex: A.Collection.Index?
+    struct DependentAccessTest<A> where A: SymbolTestsCore.DependentTypeAccess.OuterProtocol {
+        var middleLeaf: A.OuterProtocol.Middle.MiddleProtocol.Leaf?
+        var innerValue: A.OuterProtocol.Inner.InnerProtocol.Value?
 
-        init(iteratorElement: A.Element?, indicesIndex: A.Index?, subSequenceIndex: A.Index?)
+        init(middleLeaf: A.Middle.Leaf?, innerValue: A.Inner.Value?)
     }
-    struct DeepDependentAccessTest<A> where A: Swift.Collection {
-        var deepElement: A.Sequence.Element?
+    struct DeepDependentAccessTest<A> where A: SymbolTestsCore.DependentTypeAccess.OuterProtocol {
+        var branchFinal: A.OuterProtocol.Middle.MiddleProtocol.Branch.BranchProtocol.Final?
 
-        init(deepElement: A.Element?)
+        init(branchFinal: A.Middle.Branch.Final?)
     }
     struct DependentFunctionTest {
-        func acceptDependent<A>(_: A, iteratorElement: A.Element, indicesElement: A.Index) -> A.SubSequence where A: Swift.Collection
+        func acceptDependent<A>(_: A, middleLeaf: A.Middle.Leaf, innerValue: A.Inner.Value) -> A.Middle.Branch.Final? where A: SymbolTestsCore.DependentTypeAccess.OuterProtocol
     }
-    protocol DependentProtocol where Self.First == Self.Second.Element, Self.Second: Swift.Collection {
+    protocol OuterProtocol where Self.Inner: SymbolTestsCore.DependentTypeAccess.InnerProtocol, Self.Middle: SymbolTestsCore.DependentTypeAccess.MiddleProtocol {
+        associatedtype Middle
+        associatedtype Inner
+    }
+    protocol MiddleProtocol where Self.Branch: SymbolTestsCore.DependentTypeAccess.BranchProtocol {
+        associatedtype Leaf
+        associatedtype Branch
+    }
+    protocol BranchProtocol {
+        associatedtype Final
+    }
+    protocol InnerProtocol {
+        associatedtype Value
+    }
+    protocol DependentProtocol where Self.First == Self.Second.Leaf, Self.Second: SymbolTestsCore.DependentTypeAccess.MiddleProtocol {
         associatedtype First
         associatedtype Second
     }
@@ -690,7 +715,7 @@ enum DiamondInheritance {
 }
 enum DistributedActors {
     actor DistributedActorTest {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         let id: Distributed.LocalTestingActorID
         let actorSystem: Distributed.LocalTestingDistributedActorSystem
 
@@ -714,7 +739,7 @@ enum DistributedActors {
         static func resolve(id: Distributed.LocalTestingActorID, using: Distributed.LocalTestingDistributedActorSystem) throws -> SymbolTestsCore.DistributedActors.DistributedActorTest
     }
     actor GenericDistributedActorTest<A> where A: Swift.Decodable, A: Swift.Encodable {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         let id: Distributed.LocalTestingActorID
         let actorSystem: Distributed.LocalTestingDistributedActorSystem
 
@@ -958,12 +983,14 @@ enum FieldDescriptorVariants {
         init(mutableField: Swift.Int, immutableField: Swift.String, mutableOptional: Swift.Double?, immutableOptional: Swift.Int?)
     }
     class ReferenceFieldTest {
-        weak var weakField: Swift.AnyObject?
-        var unownedField: 
-        var unownedUnsafeField: 
-        var strongField: Swift.AnyObject
-
-        init(reference: Swift.AnyObject)
+        weak var weakVarField: Swift.AnyObject?
+        weak let weakLetField: Swift.AnyObject?
+        unowned var unownedVarField: Swift.AnyObject
+        unowned let unownedLetField: Swift.AnyObject
+        unowned(unsafe) var unownedUnsafeVarField: Swift.AnyObject
+        unowned(unsafe) let unownedUnsafeLetField: Swift.AnyObject
+        var strongVarField: Swift.AnyObject
+        let strongLetField: Swift.AnyObject
     }
     struct MangledNameVariantsTest<A> {
         var concreteInt: Swift.Int
@@ -1064,6 +1091,18 @@ enum FunctionFeatures {
         func acceptAutoclosure(_: @autoclosure () -> Swift.Bool) -> Swift.Bool
         func acceptEscapingAutoclosure(_: @autoclosure () -> Swift.Bool)
         func acceptEscaping(_: () -> ())
+    }
+    struct OwnershipParameterTest {
+        class Box {
+            var value: Swift.Int
+
+            init(_: Swift.Int)
+        }
+        func consumeBox(_: consuming SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box)
+        func twoConsuming(_: consuming SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box, _: consuming SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box)
+        func consumeWithLabel(_: consuming SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box, label: Swift.Int)
+
+        static func staticConsume(_: consuming SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box)
     }
     struct VariadicFunctionTest {
         func format(_: Swift.String, _: Swift.CVarArg...) -> Swift.String
@@ -1286,7 +1325,7 @@ enum Initializers {
         init(value: Swift.Int) throws(SymbolTestsCore.Initializers.CustomInitializerError)
     }
     actor AsyncInitializerActorTest {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         let identifier: Swift.Int
 
         init(identifier: Swift.Int) async
@@ -1378,7 +1417,7 @@ enum NestedFunctions {
 enum NestedGenerics {
     struct OuterGenericTest<A> {
         struct InnerGenericTest<A1> {
-            struct InnerMostGenericTest {
+            struct InnerMostGenericTest<A2> {
                 var outer: A
                 var inner: A1
                 var innerMost: A2
@@ -1976,15 +2015,15 @@ enum WeakUnownedReferences {
         init()
     }
     class UnownedReferenceHolderTest {
-        var unownedReference: 
-        var unownedSafeReference: 
-        var unownedUnsafeReference: 
+        unowned var unownedReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
+        unowned var unownedSafeReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
+        unowned(unsafe) var unownedUnsafeReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
 
         init(target: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest)
     }
     class MixedReferenceHolderTest {
         weak var weakReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest?
-        var unownedReference: 
+        unowned var unownedReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
         var strongReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
 
         init(target: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest)
@@ -2086,6 +2125,8 @@ extension SymbolTestsCore.Actors.CustomGlobalActor: Swift.GlobalActor {
         get
     }
 }
+extension SymbolTestsCore.Actors.GlobalActorIsolatedConformanceTest: SymbolTestsCore.Actors.GlobalActorIsolatedProtocolTest {}
+extension SymbolTestsCore.Actors.GlobalActorIsolatedConformanceTest: SymbolTestsCore.Actors.CustomGlobalActorIsolatedProtocolTest {}
 extension SymbolTestsCore.AssociatedTypeWitnessPatterns.ConcreteWitnessTest: SymbolTestsCore.AssociatedTypeWitnessPatterns.AssociatedPatternProtocol {}
 extension SymbolTestsCore.AssociatedTypeWitnessPatterns.NestedWitnessTest: SymbolTestsCore.AssociatedTypeWitnessPatterns.AssociatedPatternProtocol {}
 extension SymbolTestsCore.AssociatedTypeWitnessPatterns.GenericParameterWitnessTest: SymbolTestsCore.AssociatedTypeWitnessPatterns.AssociatedPatternProtocol {}
@@ -3014,22 +3055,22 @@ extension SymbolTestsCore.OptionSetAndRawRepresentable.OptionSetTest: Swift.RawR
 }
 extension SymbolTestsCore.OptionSetAndRawRepresentable.OptionSetTest: Swift.SetAlgebra {
     init()
-    init<A1>(_: __owned A1) where A1: Swift.Sequence, Self.Element == A1.Element
+    init<A1>(_: consuming A1) where A1: Swift.Sequence, Self.Element == A1.Element
 
     var isEmpty: Swift.Bool {
         get
     }
 
     func isSuperset(of: Self) -> Swift.Bool
-    func union(_: __owned Self) -> Self
+    func union(_: consuming Self) -> Self
     func intersection(_: Self) -> Self
-    func symmetricDifference(_: __owned Self) -> Self
-    func insert(_: __owned Self.Element) -> (inserted: Swift.Bool, memberAfterInsert: Self.Element)
+    func symmetricDifference(_: consuming Self) -> Self
+    func insert(_: consuming Self.Element) -> (inserted: Swift.Bool, memberAfterInsert: Self.Element)
     func remove(_: Self.Element) -> Self.Element?
-    func update(with: __owned Self.Element) -> Self.Element?
-    func formUnion(_: __owned Self)
+    func update(with: consuming Self.Element) -> Self.Element?
+    func formUnion(_: consuming Self)
     func formIntersection(_: Self)
-    func formSymmetricDifference(_: __owned Self)
+    func formSymmetricDifference(_: consuming Self)
     func subtracting(_: Self) -> Self
     func isSubset(of: Self) -> Swift.Bool
     func isDisjoint(with: Self) -> Swift.Bool


### PR DESCRIPTION
## Summary

Roadmap **P1-7** (`Roadmaps/2026-04-13-swiftinterface-dump-improvements.md`).

Parameters declared with `consuming` or `borrowing` lose their keyword in the dump and print as bare types. The information IS in the mangling — the `'n'` (owned) / `'h'` (shared) flags from `list-type` survive into the demangler as `.owned` / `.shared` nodes — we just weren't translating them to source-level Swift 5.9+ spellings.

- `NodePrintable` `.owned` branch now emits `consuming ` (instead of `__owned `)
- New `.shared` branch emits `borrowing ` (the `__shared` legacy spelling and Swift 5.9+ `borrowing` mangle the same way)
- New fixture `OwnershipParameterTest` exercises single/multi/labeled/static `consuming` parameters

## ABI limitations (documented inline)

- **`init(consuming X)` is not recoverable** — Swift compiler does not emit the `n` flag for constructor symbols. `~Copyable` types treat by-value parameters as implicitly consuming, so the keyword is the default and never mangled.
- **Source-level `borrowing` is not recoverable** — `borrowing` mangles byte-identically to no modifier; only the legacy `__shared` spelling sets the `h` flag.

Both are explicitly documented in the test fixture comments and in the modification points of P1-7.

## Test plan

- [x] `MachOFileInterfaceSnapshotTests/interfaceSnapshot` regenerated and passing
- [ ] `OwnershipParameterTest.consumeBox/twoConsuming/consumeWithLabel/staticConsume` show `consuming Box`
- [ ] `OptionSetTest`'s `SetAlgebra` witnesses (`union`, `insert`, `formUnion`, etc.) show `consuming` instead of `__owned`
- [ ] `InoutFunctionTest.swap/modify` continue to print `inout` (unaffected, separate node kind)