### PR TITLE
feat(SwiftInterface): merge duplicate typealias-only conformance extensions

### DIFF
--- a/Sources/SwiftDump/Dumper/AssociatedTypeDumper.swift
+++ b/Sources/SwiftDump/Dumper/AssociatedTypeDumper.swift
@@ -70,6 +70,69 @@ package struct AssociatedTypeDumper<MachO: MachOSwiftSectionRepresentableWithCac
         }
     }
 
+    /// Emits a deduplicated typealias block collected from every supplied ``AssociatedType``.
+    ///
+    /// When an extension is materialized from multiple sibling conformances (e.g. `Sequence`
+    /// + `Collection` + `BidirectionalCollection`), each conformance contributes its own
+    /// `AssociatedType` descriptor whose records overlap. Merging them verbatim produces
+    /// duplicate `typealias` lines; this helper dedupes by `(record name, mangled
+    /// substituted type)` so each unique entry prints once while preserving the first-seen
+    /// ordering.
+    @SemanticStringBuilder
+    package static func mergedRecords(of associatedTypes: [AssociatedType], using configuration: DumperConfiguration, in machO: MachO) async throws -> SemanticString {
+        let orderedRecords = collectUniqueRecords(of: associatedTypes, in: machO)
+        let resolver = configuration.demangleResolver
+        for (offset, record) in orderedRecords.offsetEnumerated() {
+            BreakLine()
+
+            Indent(level: 1)
+
+            Keyword(.typealias)
+
+            Space()
+
+            TypeDeclaration(kind: .other, record.name)
+
+            Space()
+
+            Standard("=")
+
+            Space()
+
+            try await resolver.resolve(for: MetadataReader.demangleType(for: record.mangledTypeName, in: machO).resolveOpaqueType(in: machO))
+
+            if offset.isEnd {
+                BreakLine()
+            }
+        }
+    }
+
+    private struct AssociatedTypeRecordDedupKey: Hashable {
+        let name: String
+        let mangledTypeName: MangledName
+    }
+
+    private static func collectUniqueRecords(of associatedTypes: [AssociatedType], in machO: MachO) -> [(name: String, mangledTypeName: MangledName)] {
+        var seenKeys: Set<AssociatedTypeRecordDedupKey> = []
+        var orderedRecords: [(name: String, mangledTypeName: MangledName)] = []
+        for associatedType in associatedTypes {
+            for record in associatedType.records {
+                let recordName: String
+                let mangledTypeName: MangledName
+                do {
+                    recordName = try record.name(in: machO)
+                    mangledTypeName = try record.substitutedTypeName(in: machO)
+                } catch {
+                    continue
+                }
+                if seenKeys.insert(AssociatedTypeRecordDedupKey(name: recordName, mangledTypeName: mangledTypeName)).inserted {
+                    orderedRecords.append((recordName, mangledTypeName))
+                }
+            }
+        }
+        return orderedRecords
+    }
+
     package var body: SemanticString {
         get async throws {
             try await declaration

--- a/Sources/SwiftInterface/Components/Definitions/ExtensionDefinition.swift
+++ b/Sources/SwiftInterface/Components/Definitions/ExtensionDefinition.swift
@@ -16,7 +16,7 @@ public final class ExtensionDefinition: Definition, MutableDefinition {
 
     public let protocolConformance: ProtocolConformance?
 
-    public let associatedType: AssociatedType?
+    public internal(set) var associatedTypes: [AssociatedType]
 
     public internal(set) var types: [TypeDefinition] = []
 
@@ -50,11 +50,11 @@ public final class ExtensionDefinition: Definition, MutableDefinition {
         !variables.isEmpty || !functions.isEmpty || !staticVariables.isEmpty || !staticFunctions.isEmpty || !allocators.isEmpty || !constructors.isEmpty || !staticSubscripts.isEmpty || !subscripts.isEmpty
     }
 
-    public init<MachO: MachOSwiftSectionRepresentableWithCache>(extensionName: ExtensionName, genericSignature: Node?, protocolConformance: ProtocolConformance?, associatedType: AssociatedType?, in machO: MachO) throws {
+    public init<MachO: MachOSwiftSectionRepresentableWithCache>(extensionName: ExtensionName, genericSignature: Node?, protocolConformance: ProtocolConformance?, associatedTypes: [AssociatedType] = [], in machO: MachO) throws {
         self.extensionName = extensionName
         self.genericSignature = genericSignature
         self.protocolConformance = protocolConformance
-        self.associatedType = associatedType
+        self.associatedTypes = associatedTypes
     }
 
     package func index<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO) async throws {

--- a/Sources/SwiftInterface/Components/Definitions/ProtocolDefinition.swift
+++ b/Sources/SwiftInterface/Components/Definitions/ProtocolDefinition.swift
@@ -121,7 +121,7 @@ public final class ProtocolDefinition: Definition, MutableDefinition {
 
         orderedMembers = OrderedMember.pwtOrdered(OrderedMember.allMembers(from: self))
 
-        let extensionDefinition = try ExtensionDefinition(extensionName: protocolName.extensionName, genericSignature: nil, protocolConformance: nil, associatedType: nil, in: machO)
+        let extensionDefinition = try ExtensionDefinition(extensionName: protocolName.extensionName, genericSignature: nil, protocolConformance: nil, in: machO)
 
         extensionDefinition.setDefinitions(for: defaultImplementationMemberSymbolsByKind, inExtension: true)
         extensionDefinition.orderedMembers = OrderedMember.offsetOrdered(OrderedMember.allMembers(from: extensionDefinition))

--- a/Sources/SwiftInterface/SwiftInterfaceIndexer.swift
+++ b/Sources/SwiftInterface/SwiftInterfaceIndexer.swift
@@ -330,18 +330,18 @@ public final class SwiftInterfaceIndexer<MachO: MachOSwiftSectionRepresentableWi
                         genericSignature = try MetadataReader.buildGenericSignature(for: currentRequirements, in: machO)
                     }
 
-                    let extensionDefinition = try ExtensionDefinition(extensionName: extensionTypeName.extensionName, genericSignature: genericSignature, protocolConformance: nil, associatedType: nil, in: machO)
+                    let extensionDefinition = try ExtensionDefinition(extensionName: extensionTypeName.extensionName, genericSignature: genericSignature, protocolConformance: nil, in: machO)
                     extensionDefinition.types = [typeDefinition]
                     currentStorage.typeExtensionDefinitions[extensionDefinition.extensionName, default: []].append(extensionDefinition)
                 case .type(let parentType):
                     let parentTypeName = try parentType.typeName(in: machO)
-                    let extensionDefinition = try ExtensionDefinition(extensionName: parentTypeName.extensionName, genericSignature: nil, protocolConformance: nil, associatedType: nil, in: machO)
+                    let extensionDefinition = try ExtensionDefinition(extensionName: parentTypeName.extensionName, genericSignature: nil, protocolConformance: nil, in: machO)
                     extensionDefinition.types = [typeDefinition]
                     currentStorage.typeExtensionDefinitions[extensionDefinition.extensionName, default: []].append(extensionDefinition)
                 case .symbol(let symbol):
                     guard let type = try MetadataReader.demangleType(for: symbol, in: machO)?.first(of: .type), let kind = type.typeKind else { continue }
                     let parentTypeName = TypeName(node: type, kind: kind)
-                    let extensionDefinition = try ExtensionDefinition(extensionName: parentTypeName.extensionName, genericSignature: nil, protocolConformance: nil, associatedType: nil, in: machO)
+                    let extensionDefinition = try ExtensionDefinition(extensionName: parentTypeName.extensionName, genericSignature: nil, protocolConformance: nil, in: machO)
                     extensionDefinition.types = [typeDefinition]
                     currentStorage.typeExtensionDefinitions[extensionDefinition.extensionName, default: []].append(extensionDefinition)
                 }
@@ -395,7 +395,7 @@ public final class SwiftInterfaceIndexer<MachO: MachOSwiftSectionRepresentableWi
                         if let currentRequirements = extensionContext.genericContext?.uniqueCurrentRequirements(in: machO), !currentRequirements.isEmpty {
                             genericSignature = try MetadataReader.buildGenericSignature(for: currentRequirements, in: machO)
                         }
-                        let extensionDefinition = try ExtensionDefinition(extensionName: typeName.extensionName, genericSignature: genericSignature, protocolConformance: nil, associatedType: nil, in: machO)
+                        let extensionDefinition = try ExtensionDefinition(extensionName: typeName.extensionName, genericSignature: genericSignature, protocolConformance: nil, in: machO)
                         extensionDefinition.protocols = [protocolDefinition]
                         currentStorage.typeExtensionDefinitions[extensionDefinition.extensionName, default: []].append(extensionDefinition)
                     }
@@ -486,7 +486,7 @@ public final class SwiftInterfaceIndexer<MachO: MachOSwiftSectionRepresentableWi
                         }
                     }
 
-                    let extensionDefinition = try ExtensionDefinition(extensionName: typeName.extensionName, genericSignature: MetadataReader.buildGenericSignature(for: protocolConformance.conditionalRequirements, in: machO), protocolConformance: protocolConformance, associatedType: associatedType, in: machO)
+                    let extensionDefinition = try ExtensionDefinition(extensionName: typeName.extensionName, genericSignature: MetadataReader.buildGenericSignature(for: protocolConformance.conditionalRequirements, in: machO), protocolConformance: protocolConformance, associatedTypes: associatedType.map { [$0] } ?? [], in: machO)
                     extensionDefinition.isRetroactive = protocolConformance.flags.isRetroactive
                     conformanceExtensionDefinitions[extensionDefinition.extensionName, default: []].append(extensionDefinition)
                     extensionCount += 1
@@ -500,12 +500,43 @@ public final class SwiftInterfaceIndexer<MachO: MachOSwiftSectionRepresentableWi
         }
         for (remainingTypeName, remainingAssociatedTypeByProtocolName) in associatedTypesByTypeNameCopy {
             for (_, remainingAssociatedType) in remainingAssociatedTypeByProtocolName {
-                let extensionDefinition = try ExtensionDefinition(extensionName: remainingTypeName.extensionName, genericSignature: nil, protocolConformance: nil, associatedType: remainingAssociatedType, in: machO)
+                let extensionDefinition = try ExtensionDefinition(extensionName: remainingTypeName.extensionName, genericSignature: nil, protocolConformance: nil, associatedTypes: [remainingAssociatedType], in: machO)
                 conformanceExtensionDefinitions[extensionDefinition.extensionName, default: []].append(extensionDefinition)
             }
         }
 
-        currentStorage.conformanceExtensionDefinitions = conformanceExtensionDefinitions
+        // P1-9: Merge typealias-only conformance extensions that share the same extended
+        // type. The binary emits one AssociatedType descriptor per protocol requirement,
+        // so a type conforming to multiple related protocols (e.g. Sequence + Collection
+        // + BidirectionalCollection) ends up with several bare `extension X { typealias
+        // ... }` blocks whose entries overlap. A typealias-only extension has no
+        // `protocolConformance`, no `genericSignature`, no nested types or protocols — we
+        // can safely union their `associatedTypes` into one representative block. Order is
+        // preserved by folding successors into the first occurrence.
+        var mergedConformanceExtensionDefinitions: OrderedDictionary<ExtensionName, [ExtensionDefinition]> = [:]
+        for (extensionName, extensions) in conformanceExtensionDefinitions {
+            var primaryTypealiasOnly: ExtensionDefinition? = nil
+            var preservedExtensions: [ExtensionDefinition] = []
+            for extensionDefinition in extensions {
+                let isTypealiasOnly = extensionDefinition.protocolConformance == nil
+                    && extensionDefinition.genericSignature == nil
+                    && extensionDefinition.types.isEmpty
+                    && extensionDefinition.protocols.isEmpty
+                if isTypealiasOnly {
+                    if let existing = primaryTypealiasOnly {
+                        existing.associatedTypes.append(contentsOf: extensionDefinition.associatedTypes)
+                    } else {
+                        primaryTypealiasOnly = extensionDefinition
+                        preservedExtensions.append(extensionDefinition)
+                    }
+                } else {
+                    preservedExtensions.append(extensionDefinition)
+                }
+            }
+            mergedConformanceExtensionDefinitions[extensionName] = preservedExtensions
+        }
+
+        currentStorage.conformanceExtensionDefinitions = mergedConformanceExtensionDefinitions
 
         // Populate conforming protocol names on each TypeDefinition for attribute inference
         for (typeName, conformances) in protocolConformancesByTypeName {
@@ -552,7 +583,7 @@ public final class SwiftInterfaceIndexer<MachO: MachOSwiftSectionRepresentableWi
             }
 
             func extensionDefinition(of kind: ExtensionKind, for memberSymbolsByKind: OrderedDictionary<SymbolIndexStore.MemberKind, [DemangledSymbol]>, genericSignature: Node?) throws -> ExtensionDefinition {
-                let extensionDefinition = try ExtensionDefinition(extensionName: .init(node: node, kind: kind), genericSignature: genericSignature, protocolConformance: nil, associatedType: nil, in: machO)
+                let extensionDefinition = try ExtensionDefinition(extensionName: .init(node: node, kind: kind), genericSignature: genericSignature, protocolConformance: nil, in: machO)
                 var memberCount = 0
 
                 for (kind, memberSymbols) in memberSymbolsByKind {

--- a/Sources/SwiftInterface/SwiftInterfacePrinter.swift
+++ b/Sources/SwiftInterface/SwiftInterfacePrinter.swift
@@ -218,9 +218,12 @@ public final class SwiftInterfacePrinter<MachO: MachOSwiftSectionRepresentableWi
                 }
             }
 
-            if let associatedType = extensionDefinition.associatedType {
-                let dumper = AssociatedTypeDumper(associatedType, using: .init(demangleResolver: typeDemangleResolver), in: machO)
-                try await dumper.records
+            if !extensionDefinition.associatedTypes.isEmpty {
+                try await AssociatedTypeDumper.mergedRecords(
+                    of: extensionDefinition.associatedTypes,
+                    using: .init(demangleResolver: typeDemangleResolver),
+                    in: machO
+                )
             }
 
             try await printDefinition(extensionDefinition, level: 1)

--- a/Tests/SwiftInterfaceTests/Snapshots/__Snapshots__/MachOFileInterfaceSnapshotTests/interfaceSnapshot.1.txt
+++ b/Tests/SwiftInterfaceTests/Snapshots/__Snapshots__/MachOFileInterfaceSnapshotTests/interfaceSnapshot.1.txt
@@ -52,7 +52,7 @@ enum AccessLevels {
 }
 enum Actors {
     actor ActorTest {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         var state: Swift.Int
 
         var unownedExecutor: Swift.UnownedSerialExecutor {
@@ -65,7 +65,7 @@ enum Actors {
     }
     @globalActor
     actor CustomGlobalActor {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
 
         var unownedExecutor: Swift.UnownedSerialExecutor {
             get
@@ -83,6 +83,18 @@ enum Actors {
 
         func nonisolatedMethod() -> Swift.String
         func method() -> Swift.Int
+    }
+    class GlobalActorIsolatedConformanceTest {
+        init()
+
+        func customIsolatedRequirement()
+        func isolatedRequirement()
+    }
+    protocol GlobalActorIsolatedProtocolTest {
+        func isolatedRequirement()
+    }
+    protocol CustomGlobalActorIsolatedProtocolTest {
+        func customIsolatedRequirement()
     }
 }
 enum AssociatedTypeWitnessPatterns {
@@ -615,7 +627,7 @@ enum DeinitVariants {
         init()
     }
     actor ActorDeinitTest {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         var state: Swift.Int
 
         init()
@@ -631,22 +643,35 @@ enum DeinitVariants {
     }
 }
 enum DependentTypeAccess {
-    struct DependentAccessTest<A> where A: Swift.Collection {
-        var iteratorElement: A.Sequence.Element?
-        var indicesIndex: A.Collection.Index?
-        var subSequenceIndex: A.Collection.Index?
+    struct DependentAccessTest<A> where A: SymbolTestsCore.DependentTypeAccess.OuterProtocol {
+        var middleLeaf: A.OuterProtocol.Middle.MiddleProtocol.Leaf?
+        var innerValue: A.OuterProtocol.Inner.InnerProtocol.Value?
 
-        init(iteratorElement: A.Element?, indicesIndex: A.Index?, subSequenceIndex: A.Index?)
+        init(middleLeaf: A.Middle.Leaf?, innerValue: A.Inner.Value?)
     }
-    struct DeepDependentAccessTest<A> where A: Swift.Collection {
-        var deepElement: A.Sequence.Element?
+    struct DeepDependentAccessTest<A> where A: SymbolTestsCore.DependentTypeAccess.OuterProtocol {
+        var branchFinal: A.OuterProtocol.Middle.MiddleProtocol.Branch.BranchProtocol.Final?
 
-        init(deepElement: A.Element?)
+        init(branchFinal: A.Middle.Branch.Final?)
     }
     struct DependentFunctionTest {
-        func acceptDependent<A>(_: A, iteratorElement: A.Element, indicesElement: A.Index) -> A.SubSequence where A: Swift.Collection
+        func acceptDependent<A>(_: A, middleLeaf: A.Middle.Leaf, innerValue: A.Inner.Value) -> A.Middle.Branch.Final? where A: SymbolTestsCore.DependentTypeAccess.OuterProtocol
     }
-    protocol DependentProtocol where Self.First == Self.Second.Element, Self.Second: Swift.Collection {
+    protocol OuterProtocol where Self.Inner: SymbolTestsCore.DependentTypeAccess.InnerProtocol, Self.Middle: SymbolTestsCore.DependentTypeAccess.MiddleProtocol {
+        associatedtype Middle
+        associatedtype Inner
+    }
+    protocol MiddleProtocol where Self.Branch: SymbolTestsCore.DependentTypeAccess.BranchProtocol {
+        associatedtype Leaf
+        associatedtype Branch
+    }
+    protocol BranchProtocol {
+        associatedtype Final
+    }
+    protocol InnerProtocol {
+        associatedtype Value
+    }
+    protocol DependentProtocol where Self.First == Self.Second.Leaf, Self.Second: SymbolTestsCore.DependentTypeAccess.MiddleProtocol {
         associatedtype First
         associatedtype Second
     }
@@ -690,7 +715,7 @@ enum DiamondInheritance {
 }
 enum DistributedActors {
     actor DistributedActorTest {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         let id: Distributed.LocalTestingActorID
         let actorSystem: Distributed.LocalTestingDistributedActorSystem
 
@@ -714,7 +739,7 @@ enum DistributedActors {
         static func resolve(id: Distributed.LocalTestingActorID, using: Distributed.LocalTestingDistributedActorSystem) throws -> SymbolTestsCore.DistributedActors.DistributedActorTest
     }
     actor GenericDistributedActorTest<A> where A: Swift.Decodable, A: Swift.Encodable {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         let id: Distributed.LocalTestingActorID
         let actorSystem: Distributed.LocalTestingDistributedActorSystem
 
@@ -958,12 +983,14 @@ enum FieldDescriptorVariants {
         init(mutableField: Swift.Int, immutableField: Swift.String, mutableOptional: Swift.Double?, immutableOptional: Swift.Int?)
     }
     class ReferenceFieldTest {
-        weak var weakField: Swift.AnyObject?
-        var unownedField: 
-        var unownedUnsafeField: 
-        var strongField: Swift.AnyObject
-
-        init(reference: Swift.AnyObject)
+        weak var weakVarField: Swift.AnyObject?
+        weak let weakLetField: Swift.AnyObject?
+        unowned var unownedVarField: Swift.AnyObject
+        unowned let unownedLetField: Swift.AnyObject
+        unowned(unsafe) var unownedUnsafeVarField: Swift.AnyObject
+        unowned(unsafe) let unownedUnsafeLetField: Swift.AnyObject
+        var strongVarField: Swift.AnyObject
+        let strongLetField: Swift.AnyObject
     }
     struct MangledNameVariantsTest<A> {
         var concreteInt: Swift.Int
@@ -1064,6 +1091,18 @@ enum FunctionFeatures {
         func acceptAutoclosure(_: @autoclosure () -> Swift.Bool) -> Swift.Bool
         func acceptEscapingAutoclosure(_: @autoclosure () -> Swift.Bool)
         func acceptEscaping(_: () -> ())
+    }
+    struct OwnershipParameterTest {
+        class Box {
+            var value: Swift.Int
+
+            init(_: Swift.Int)
+        }
+        func consumeBox(_: __owned SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box)
+        func twoConsuming(_: __owned SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box, _: __owned SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box)
+        func consumeWithLabel(_: __owned SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box, label: Swift.Int)
+
+        static func staticConsume(_: __owned SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box)
     }
     struct VariadicFunctionTest {
         func format(_: Swift.String, _: Swift.CVarArg...) -> Swift.String
@@ -1286,7 +1325,7 @@ enum Initializers {
         init(value: Swift.Int) throws(SymbolTestsCore.Initializers.CustomInitializerError)
     }
     actor AsyncInitializerActorTest {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         let identifier: Swift.Int
 
         init(identifier: Swift.Int) async
@@ -1378,7 +1417,7 @@ enum NestedFunctions {
 enum NestedGenerics {
     struct OuterGenericTest<A> {
         struct InnerGenericTest<A1> {
-            struct InnerMostGenericTest {
+            struct InnerMostGenericTest<A2> {
                 var outer: A
                 var inner: A1
                 var innerMost: A2
@@ -1976,15 +2015,15 @@ enum WeakUnownedReferences {
         init()
     }
     class UnownedReferenceHolderTest {
-        var unownedReference: 
-        var unownedSafeReference: 
-        var unownedUnsafeReference: 
+        unowned var unownedReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
+        unowned var unownedSafeReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
+        unowned(unsafe) var unownedUnsafeReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
 
         init(target: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest)
     }
     class MixedReferenceHolderTest {
         weak var weakReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest?
-        var unownedReference: 
+        unowned var unownedReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
         var strongReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
 
         init(target: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest)
@@ -2086,6 +2125,8 @@ extension SymbolTestsCore.Actors.CustomGlobalActor: Swift.GlobalActor {
         get
     }
 }
+extension SymbolTestsCore.Actors.GlobalActorIsolatedConformanceTest: SymbolTestsCore.Actors.GlobalActorIsolatedProtocolTest {}
+extension SymbolTestsCore.Actors.GlobalActorIsolatedConformanceTest: SymbolTestsCore.Actors.CustomGlobalActorIsolatedProtocolTest {}
 extension SymbolTestsCore.AssociatedTypeWitnessPatterns.ConcreteWitnessTest: SymbolTestsCore.AssociatedTypeWitnessPatterns.AssociatedPatternProtocol {}
 extension SymbolTestsCore.AssociatedTypeWitnessPatterns.NestedWitnessTest: SymbolTestsCore.AssociatedTypeWitnessPatterns.AssociatedPatternProtocol {}
 extension SymbolTestsCore.AssociatedTypeWitnessPatterns.GenericParameterWitnessTest: SymbolTestsCore.AssociatedTypeWitnessPatterns.AssociatedPatternProtocol {}
@@ -3178,25 +3219,11 @@ extension SymbolTestsCore.CollectionConformances.CustomCollectionTest {
     typealias SubSequence = Swift.Slice<SymbolTestsCore.CollectionConformances.CustomCollectionTest>
     typealias Indices = Swift.DefaultIndices<SymbolTestsCore.CollectionConformances.CustomCollectionTest>
 }
-extension SymbolTestsCore.CollectionConformances.CustomCollectionTest {
-    typealias Element = Swift.Int
-    typealias Iterator = Swift.IndexingIterator<SymbolTestsCore.CollectionConformances.CustomCollectionTest>
-}
 extension SymbolTestsCore.CollectionConformances.CustomBidirectionalCollectionTest {
     typealias Element = Swift.String
     typealias Index = Swift.Int
     typealias SubSequence = Swift.Slice<SymbolTestsCore.CollectionConformances.CustomBidirectionalCollectionTest>
     typealias Indices = Swift.DefaultIndices<SymbolTestsCore.CollectionConformances.CustomBidirectionalCollectionTest>
-}
-extension SymbolTestsCore.CollectionConformances.CustomBidirectionalCollectionTest {
-    typealias Element = Swift.String
-    typealias Index = Swift.Int
-    typealias Iterator = Swift.IndexingIterator<SymbolTestsCore.CollectionConformances.CustomBidirectionalCollectionTest>
-    typealias SubSequence = Swift.Slice<SymbolTestsCore.CollectionConformances.CustomBidirectionalCollectionTest>
-    typealias Indices = Swift.DefaultIndices<SymbolTestsCore.CollectionConformances.CustomBidirectionalCollectionTest>
-}
-extension SymbolTestsCore.CollectionConformances.CustomBidirectionalCollectionTest {
-    typealias Element = Swift.String
     typealias Iterator = Swift.IndexingIterator<SymbolTestsCore.CollectionConformances.CustomBidirectionalCollectionTest>
 }
 extension SymbolTestsCore.CollectionConformances.CustomRandomAccessCollectionTest {
@@ -3204,22 +3231,6 @@ extension SymbolTestsCore.CollectionConformances.CustomRandomAccessCollectionTes
     typealias Index = Swift.Int
     typealias SubSequence = Swift.Slice<SymbolTestsCore.CollectionConformances.CustomRandomAccessCollectionTest>
     typealias Indices = Swift.Range<Swift.Int>
-}
-extension SymbolTestsCore.CollectionConformances.CustomRandomAccessCollectionTest {
-    typealias Element = Swift.Double
-    typealias Index = Swift.Int
-    typealias SubSequence = Swift.Slice<SymbolTestsCore.CollectionConformances.CustomRandomAccessCollectionTest>
-    typealias Indices = Swift.Range<Swift.Int>
-}
-extension SymbolTestsCore.CollectionConformances.CustomRandomAccessCollectionTest {
-    typealias Element = Swift.Double
-    typealias Index = Swift.Int
-    typealias Iterator = Swift.IndexingIterator<SymbolTestsCore.CollectionConformances.CustomRandomAccessCollectionTest>
-    typealias SubSequence = Swift.Slice<SymbolTestsCore.CollectionConformances.CustomRandomAccessCollectionTest>
-    typealias Indices = Swift.Range<Swift.Int>
-}
-extension SymbolTestsCore.CollectionConformances.CustomRandomAccessCollectionTest {
-    typealias Element = Swift.Double
     typealias Iterator = Swift.IndexingIterator<SymbolTestsCore.CollectionConformances.CustomRandomAccessCollectionTest>
 }
 extension SymbolTestsCore.CustomLiterals.IntegerLiteralTest {
@@ -3227,11 +3238,7 @@ extension SymbolTestsCore.CustomLiterals.IntegerLiteralTest {
 }
 extension SymbolTestsCore.CustomLiterals.StringLiteralTest {
     typealias StringLiteralType = Swift.String
-}
-extension SymbolTestsCore.CustomLiterals.StringLiteralTest {
     typealias UnicodeScalarLiteralType = Swift.String
-}
-extension SymbolTestsCore.CustomLiterals.StringLiteralTest {
     typealias ExtendedGraphemeClusterLiteralType = Swift.String
 }
 extension SymbolTestsCore.CustomLiterals.ArrayLiteralTest {
@@ -3250,15 +3257,11 @@ extension SymbolTestsCore.CustomLiterals.FloatLiteralTest {
 extension SymbolTestsCore.DistributedActors.DistributedActorTest {
     typealias ActorSystem = Distributed.LocalTestingDistributedActorSystem
     typealias SerializationRequirement = Swift.Decodable & Swift.Encodable
-}
-extension SymbolTestsCore.DistributedActors.DistributedActorTest {
     typealias ID = Distributed.LocalTestingActorID
 }
 extension SymbolTestsCore.DistributedActors.GenericDistributedActorTest {
     typealias ActorSystem = Distributed.LocalTestingDistributedActorSystem
     typealias SerializationRequirement = Swift.Decodable & Swift.Encodable
-}
-extension SymbolTestsCore.DistributedActors.GenericDistributedActorTest {
     typealias ID = Distributed.LocalTestingActorID
 }
 extension SymbolTestsCore.Extensions.ExtensionConstrainedStruct {
@@ -3266,8 +3269,6 @@ extension SymbolTestsCore.Extensions.ExtensionConstrainedStruct {
 }
 extension SymbolTestsCore.Generics.GenericRequirementTest {
     typealias Body = A
-}
-extension SymbolTestsCore.Generics.GenericRequirementTest {
     typealias RawValue = A
 }
 extension SymbolTestsCore.Generics.GenericPackTest {
@@ -3281,14 +3282,7 @@ extension SymbolTestsCore.OpaqueReturnTypes.OpaqueReturnTypeTest.AnyProtocolTest
 }
 extension SymbolTestsCore.OptionSetAndRawRepresentable.OptionSetTest {
     typealias Element = SymbolTestsCore.OptionSetAndRawRepresentable.OptionSetTest
-}
-extension SymbolTestsCore.OptionSetAndRawRepresentable.OptionSetTest {
     typealias RawValue = Swift.UInt
-}
-extension SymbolTestsCore.OptionSetAndRawRepresentable.OptionSetTest {
-    typealias Element = SymbolTestsCore.OptionSetAndRawRepresentable.OptionSetTest
-}
-extension SymbolTestsCore.OptionSetAndRawRepresentable.OptionSetTest {
     typealias ArrayLiteralElement = SymbolTestsCore.OptionSetAndRawRepresentable.OptionSetTest
 }
 extension SymbolTestsCore.OptionSetAndRawRepresentable.StringRawRepresentableTest {
@@ -3305,14 +3299,8 @@ extension SymbolTestsCore.StringInterpolations.CustomStringInterpolationTest.Str
 }
 extension SymbolTestsCore.StringInterpolations.CustomStringInterpolationTest {
     typealias StringLiteralType = Swift.String
-}
-extension SymbolTestsCore.StringInterpolations.CustomStringInterpolationTest {
     typealias StringInterpolation = SymbolTestsCore.StringInterpolations.CustomStringInterpolationTest.StringInterpolation
-}
-extension SymbolTestsCore.StringInterpolations.CustomStringInterpolationTest {
     typealias ExtendedGraphemeClusterLiteralType = Swift.String
-}
-extension SymbolTestsCore.StringInterpolations.CustomStringInterpolationTest {
     typealias UnicodeScalarLiteralType = Swift.String
 }
 extension SymbolTestsCore.Structs.StructTest {


### PR DESCRIPTION
## Summary

Roadmap **P1-9** (`Roadmaps/2026-04-13-swiftinterface-dump-improvements.md`).

Conforming types (e.g. `Sequence + Collection + BidirectionalCollection`) ended up with 2-4 identical typealias-only `extension X { ... }` blocks because the binary emits one AssociatedType descriptor per protocol requirement. The dumper rendered each as its own extension block.

- New merge pass in `SwiftInterfaceIndexer` after conformance extensions are built: for each `(extensionName)`, if multiple extensions have no `protocolConformance`, no `genericSignature`, and no nested types/protocols, fold their `associatedTypes` into a single representative block.
- New `AssociatedTypeDumper.mergedRecords(of:using:in:)` deduplicates typealias records by `(name, mangledTypeName)` so the final output has each `typealias X = Y` once.
- `ExtensionDefinition.associatedType` (singular) becomes `associatedTypes` (plural) to support the merged set.

## Test plan

- [x] `MachOFileInterfaceSnapshotTests/interfaceSnapshot` regenerated and passing
- [ ] `CustomBidirectionalCollectionTest` shows **one** typealias extension instead of three
- [ ] `CustomRandomAccessCollectionTest` same
- [ ] `OptionSetTest` no longer has a duplicate `typealias Element = ...`
- [ ] Where-clauses still distinguish extensions correctly (no over-merging of conditional conformances)