### PR TITLE
feat(SwiftInterface): print @GlobalActor on conformance extensions

### DIFF
--- a/Roadmaps/2026-04-13-swiftinterface-dump-improvements.md
+++ b/Roadmaps/2026-04-13-swiftinterface-dump-improvements.md
@@ -357,36 +357,68 @@ In addition, the `printTypeLayout` emission inside the `fields` body of all thre
 
 These items require extending `Sources/MachOSwiftSection/Models/*` to read bits of the binary that the project does not currently parse.
 
-### P2-12. Method-level `@MainActor` / `@GlobalActor`
+### P2-12. Global actor isolation (scoped down — mostly ABI-limited)
 
-**Symptom.** Methods on `@MainActor`-annotated types and methods explicitly tagged `@MainActor` do not show the isolation attribute.
+**Original symptom.** Methods on `@MainActor`-annotated types and methods explicitly tagged `@MainActor` do not show the isolation attribute.
 
-**Evidence the information is in the binary (method-level only).**
-- `swift/include/swift/ABI/MetadataValues.h:1166` — `FunctionTypeFlags::GlobalActorMask` at bit 28.
-- `swift/include/swift/ABI/Metadata.h:1516-1580` — `TargetFunctionGlobalActorMetadata`, a trailing object on the function metadata structure.
-- `Sources/MachOSwiftSection/Models/Function/FunctionTypeFlags.swift:28` — `globalActorMask` bit is already defined; `:63` exposes `hasGlobalActor`.
-- `Sources/SwiftInterface/NodePrintables/FunctionTypeNodePrintable.swift:42,113-115` — already handles `.globalActorFunctionType` in the demangled node path when the mangled form includes it.
+**Status after investigation.** Largely **ABI-limited**. The earlier plan assumed that `TargetFunctionGlobalActorMetadata` + `FunctionTypeFlags::GlobalActorMask` could be read for arbitrary class methods. This is incorrect: those live on **function type metadata records**, which only exist for function type *values* (e.g. `var closure: @MainActor () -> Int`). Swift class method descriptors do **not** embed function type metadata — they embed flags + an impl pointer, and the signature is reconstructed from the impl symbol's mangled name. Method-level global-actor isolation is simply not in the mangled name for sync or async class methods (verified empirically with `swiftc` + `swift demangle` for both class-level and per-method `@MainActor`).
 
-**What is missing.**
-- No reader for `TargetFunctionGlobalActorMetadata` (the trailing metadata record). Implementing this lets the dumper print the concrete actor type as `@MainActor` / `@CustomGlobalActor`.
-- The method descriptor or function type encountered during dump lookup must expose `globalActorType: Node?` so the printer can emit the attribute.
+#### What already works
 
-**Not fixable (class-level attribute).** `@MainActor class X` at the class level has no `ClassFlags` bit. See the "Known limitations" section below. Only method-level / function-type-level isolation is recoverable.
+Function type values with a global actor ARE mangled and printed correctly today. The mangled form contains `ScMYc...` (class-actor reference `ScM` + `globalActorFunctionType` `Yc`), and `Sources/SwiftInterface/NodePrintables/FunctionTypeNodePrintable.swift:42,113-115` already dispatches on `.globalActorFunctionType` to emit `@Swift.MainActor`. Covered cases:
 
-**Modification points.**
-1. New model file `Sources/MachOSwiftSection/Models/Function/TargetFunctionGlobalActorMetadata.swift` — struct with layout mirroring the C++ definition, readable via the existing `Readable` / `ReadingContext` infrastructure.
-2. Extend `Sources/MachOSwiftSection/Models/Function/FunctionType.swift` (or equivalent) to expose the trailing global actor metadata when `hasGlobalActor` is true.
-3. `Sources/SwiftInterface/AttributeInference/TypeAttributeInferrer.swift:80-142` — the current inference is based on protocol conformance (detecting `@propertyWrapper` etc.). Add a method-level attribute inferrer (`FunctionAttributeInferrer`) that reads the global-actor metadata and outputs a `SwiftAttribute.globalActor(typeName: String)`.
-4. `SwiftInterfacePrinter.printThrowingFunction` — emit the inferred attributes above the function declaration.
+- **Closure parameters** — `FunctionFeatures.MainActorClosureTest.acceptMainActorClosure(_:)` prints as `func acceptMainActorClosure(_: @Swift.MainActor @Sendable () -> ())`. ✓
+- **Closure return types / typealiases / property types** — any spot where the source writes `@MainActor () -> T` at the function type position.
 
-**Verification.**
-- `FunctionFeatures.MainActorClosureTest` methods should gain `@MainActor` attributes where appropriate.
-- `Actors.MainActorAnnotatedTest.method` currently prints without isolation — after the fix, the methods should show `@MainActor`.
-- `Actors.GlobalActorAnnotatedClass.method` should show `@CustomGlobalActor`.
+No code change is required for these; the existing node printer handles them.
 
-**Risk.** The trailing object calculation must match the runtime's layout exactly; off-by-one in trailing-object offsets is easy to introduce. Cross-check with `swift/lib/IRGen/GenProto.cpp` for the emission order.
+#### ABI limitation 1 — class-level `@MainActor`
 
-**Effort.** Medium-large (1.5 days). Main work is the reader + validation.
+```swift
+@MainActor public class C { public func f() -> Int { 0 } }
+```
+
+There is **no `ClassFlags` bit** for class-level global-actor isolation, and the class descriptor does not reference a global actor type. The class is indistinguishable from a plain class in the binary. Acknowledged in the "Known limitations" section below.
+
+#### ABI limitation 2 — method-level `@MainActor` on a class method
+
+```swift
+public class D {
+    @MainActor public func g() -> Int { 0 }
+}
+```
+
+The method impl symbol is `_$s8TestMain1DC1gSiyF`, which demangles to `D.g() -> Int` — no `ScM`, no `Yc`, no isolation marker. Empirically verified with `swiftc -emit-library` + `nm`. The same holds for `async` variants (`YaF` — async bit set, global-actor bit absent). There is no secondary symbol, no trailing metadata, no hidden descriptor that carries this information. `TargetFunctionGlobalActorMetadata` is only populated for function *type values*, not class method descriptors, so reading it would not recover this data either.
+
+Method descriptors carry `MethodDescriptorFlags` (`Sources/MachOSwiftSection/Models/Type/Class/Method/MethodDescriptorFlags.swift`) which has room for kind / isInstance / isAsync / isDynamic / extra discriminator — there is **no** global-actor bit and no reference to an actor type.
+
+#### Recoverable subset: protocol conformance global-actor isolation
+
+```swift
+@MainActor extension Foo: SomeProtocol { ... }
+```
+
+This **is** recoverable. `ProtocolConformanceFlags::hasGlobalActorIsolation` (bit 19) is set and the conformance descriptor has a trailing **reference to the global actor type** (see `swift/include/swift/ABI/Metadata.h` — `TargetProtocolConformanceDescriptor::getGlobalActorIsolationType`). Evidence already in the project:
+
+- `Sources/MachOSwiftSection/Models/ProtocolConformance/ProtocolConformanceFlags.swift:27,81-83` — flag is defined and a public `hasGlobalActorIsolation` getter exists.
+- `Sources/MachOSwiftSection/Models/ProtocolConformance/ProtocolConformance.swift` (or its descriptor) — does **not** yet read the trailing `globalActorIsolation` reference.
+
+This subset is the only piece that can be honestly implemented. Scope:
+
+1. Extend `ProtocolConformanceDescriptor` (and its trailing-object layout) to read the trailing `RelativeDirectPointer<MangledName>` (conditional on `hasGlobalActorIsolation`).
+2. Expose `globalActorTypeName: MangledName?` / `globalActorTypeNode: Node?` on `ProtocolConformance`.
+3. In `SwiftInterfacePrinter.printExtensionDefinition`, when `extensionDefinition.protocolConformance?.globalActorTypeNode` is non-nil, emit `@<resolved actor type>` in front of the `extension` keyword.
+
+#### Verification (scoped to the recoverable subset)
+
+- `FunctionFeatures.MainActorClosureTest` — already prints `@Swift.MainActor` in closure parameter positions; no code change required (regression guard).
+- `Actors.MainActorAnnotatedTest.method` — **will not gain** `@MainActor`. Document in fixture comments.
+- `Actors.GlobalActorAnnotatedClass.method` — **will not gain** `@CustomGlobalActor`. Document in fixture comments.
+- New fixture (or reuse of existing): `@MainActor extension Foo: SomeProtocol { ... }` — the `extension` block should print `@Swift.MainActor extension Foo: SomeProtocol`.
+
+#### Effort (scoped)
+
+Small-medium (half a day): conformance descriptor layout extension + node-emit path in the extension printer. Skipped portion (method-level) costs 0 because it is not feasible.
 
 ---
 

--- a/Sources/MachOSwiftSection/Models/ProtocolConformance/GlobalActorReference.swift
+++ b/Sources/MachOSwiftSection/Models/ProtocolConformance/GlobalActorReference.swift
@@ -1,0 +1,40 @@
+import Foundation
+import MachOKit
+import MachOFoundation
+
+/// Trailing object of `TargetProtocolConformanceDescriptor` carrying the global
+/// actor that isolates a conformance (e.g. `extension X: @MainActor P`).
+///
+/// Present iff `ProtocolConformanceFlags.hasGlobalActorIsolation` is set. Mirrors
+/// `TargetGlobalActorReference` in the Swift 6.2+ ABI: a relative pointer to the
+/// mangled actor type name followed by a relative pointer to the actor's
+/// `GlobalActor` conformance descriptor. Only the type-name pointer is used when
+/// rendering the attribute; the conformance pointer exists for runtime dispatch.
+public struct GlobalActorReference: LocatableLayoutWrapper {
+    public struct Layout: LayoutProtocol {
+        public let type: RelativeDirectPointer<MangledName>
+        /// Relative pointer to the conformance descriptor that witnesses the actor's
+        /// `GlobalActor` conformance. Stored as a raw offset because the dumper only
+        /// needs the actor type name for attribute rendering.
+        public let conformance: RelativeOffset
+    }
+
+    public var layout: Layout
+
+    public let offset: Int
+
+    public init(layout: Layout, offset: Int) {
+        self.offset = offset
+        self.layout = layout
+    }
+}
+
+extension GlobalActorReference {
+    public func typeName<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO) throws -> MangledName {
+        try layout.type.resolve(from: offset(of: \.type), in: machO)
+    }
+
+    public func typeName() throws -> MangledName {
+        try layout.type.resolve(from: pointer(of: \.type))
+    }
+}

--- a/Sources/MachOSwiftSection/Models/ProtocolConformance/ProtocolConformance.swift
+++ b/Sources/MachOSwiftSection/Models/ProtocolConformance/ProtocolConformance.swift
@@ -4,13 +4,13 @@ import MachOFoundation
 
 // using TrailingObjects = swift::ABI::TrailingObjects<
 //                           TargetProtocolConformanceDescriptor<Runtime>,
-//                           TargetRelativeContextPointer<Runtime>,
-//                           TargetGenericRequirementDescriptor<Runtime>,
-//                           GenericPackShapeDescriptor,
-//                           TargetResilientWitnessesHeader<Runtime>,
-//                           TargetResilientWitness<Runtime>,
-//                           TargetGenericWitnessTable<Runtime>,
-//                           TargetGlobalActorReference<Runtime>>;
+//                           TargetRelativeContextPointer<Runtime>,       // if isRetroactive
+//                           TargetGenericRequirementDescriptor<Runtime>, // numConditionalRequirements
+//                           GenericPackShapeDescriptor,                  // numConditionalPackShapeDescriptors
+//                           TargetResilientWitnessesHeader<Runtime>,     // if hasResilientWitnesses
+//                           TargetResilientWitness<Runtime>,             // header.NumWitnesses
+//                           TargetGenericWitnessTable<Runtime>,          // if hasGenericWitnessTable
+//                           TargetGlobalActorReference<Runtime>>;        // if hasGlobalActorIsolation
 
 // The structure of a protocol conformance.
 //
@@ -39,6 +39,8 @@ public struct ProtocolConformance: TopLevelType {
     public private(set) var resilientWitnesses: [ResilientWitness] = []
 
     public private(set) var genericWitnessTable: GenericWitnessTable?
+
+    public private(set) var globalActorReference: GlobalActorReference?
 
     public init<MachO: MachOSwiftSectionRepresentableWithCache>(descriptor: ProtocolConformanceDescriptor, in machO: MachO) throws {
         self.descriptor = descriptor
@@ -118,6 +120,14 @@ public struct ProtocolConformance: TopLevelType {
             currentOffset.offset(of: GenericWitnessTable.self)
         } else {
             genericWitnessTable = nil
+        }
+
+        if descriptor.flags.hasGlobalActorIsolation {
+            let globalActorReference: GlobalActorReference = try reader.readWrapperElement(offset: currentOffset)
+            self.globalActorReference = globalActorReference
+            currentOffset.offset(of: GlobalActorReference.self)
+        } else {
+            globalActorReference = nil
         }
     }
 }

--- a/Sources/SwiftInterface/SwiftInterfacePrinter.swift
+++ b/Sources/SwiftInterface/SwiftInterfacePrinter.swift
@@ -10,6 +10,7 @@ import Dependencies
 import Utilities
 @_spi(Internals) import MachOSymbols
 @_spi(Internals) import MachOCaches
+@_spi(Internals) import SwiftInspection
 
 @_spi(Support)
 public final class SwiftInterfacePrinter<MachO: MachOSwiftSectionRepresentableWithCache>: Sendable {
@@ -183,6 +184,13 @@ public final class SwiftInterfacePrinter<MachO: MachOSwiftSectionRepresentableWi
                 Space()
                 if extensionDefinition.isRetroactive {
                     Keyword(.atRetroactive)
+                    Space()
+                }
+                if let globalActorReference = protocolConformance.globalActorReference,
+                   let globalActorTypeName = try? globalActorReference.typeName(in: machO),
+                   let globalActorNode = try? MetadataReader.demangleType(for: globalActorTypeName, in: machO) {
+                    Standard("@")
+                    try await printThrowingType(globalActorNode, isProtocol: false, level: level)
                     Space()
                 }
                 protocolName

--- a/Tests/Projects/SymbolTests/SymbolTestsCore/Actors.swift
+++ b/Tests/Projects/SymbolTests/SymbolTestsCore/Actors.swift
@@ -37,4 +37,34 @@ public enum Actors {
 
         nonisolated public func nonisolatedMethod() -> String { "" }
     }
+
+    /// Fixture for conformance-level global actor isolation.
+    ///
+    /// `@<Actor> extension X: P { ... }` sets the
+    /// `ProtocolConformanceFlags.hasGlobalActorIsolation` bit (bit 19) on the
+    /// conformance descriptor and emits a trailing `TargetGlobalActorReference`
+    /// pointing at the actor type. The SwiftInterface dumper recovers this and
+    /// prints `extension X: @Actor P`. This is the only spelling of global-actor
+    /// isolation that is recoverable from a release binary — method- and
+    /// class-level `@MainActor` are not in the mangled name or any descriptor
+    /// bit and are documented as ABI-limited in the roadmap.
+    public protocol GlobalActorIsolatedProtocolTest {
+        func isolatedRequirement()
+    }
+
+    public protocol CustomGlobalActorIsolatedProtocolTest {
+        func customIsolatedRequirement()
+    }
+
+    public class GlobalActorIsolatedConformanceTest {
+        public init() {}
+    }
+}
+
+extension Actors.GlobalActorIsolatedConformanceTest: @MainActor Actors.GlobalActorIsolatedProtocolTest {
+    @MainActor public func isolatedRequirement() {}
+}
+
+extension Actors.GlobalActorIsolatedConformanceTest: @Actors.CustomGlobalActor Actors.CustomGlobalActorIsolatedProtocolTest {
+    @Actors.CustomGlobalActor public func customIsolatedRequirement() {}
 }

--- a/Tests/SwiftInterfaceTests/Snapshots/__Snapshots__/MachOFileInterfaceSnapshotTests/interfaceSnapshot.1.txt
+++ b/Tests/SwiftInterfaceTests/Snapshots/__Snapshots__/MachOFileInterfaceSnapshotTests/interfaceSnapshot.1.txt
@@ -52,7 +52,7 @@ enum AccessLevels {
 }
 enum Actors {
     actor ActorTest {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         var state: Swift.Int
 
         var unownedExecutor: Swift.UnownedSerialExecutor {
@@ -65,7 +65,7 @@ enum Actors {
     }
     @globalActor
     actor CustomGlobalActor {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
 
         var unownedExecutor: Swift.UnownedSerialExecutor {
             get
@@ -83,6 +83,18 @@ enum Actors {
 
         func nonisolatedMethod() -> Swift.String
         func method() -> Swift.Int
+    }
+    class GlobalActorIsolatedConformanceTest {
+        init()
+
+        func customIsolatedRequirement()
+        func isolatedRequirement()
+    }
+    protocol GlobalActorIsolatedProtocolTest {
+        func isolatedRequirement()
+    }
+    protocol CustomGlobalActorIsolatedProtocolTest {
+        func customIsolatedRequirement()
     }
 }
 enum AssociatedTypeWitnessPatterns {
@@ -615,7 +627,7 @@ enum DeinitVariants {
         init()
     }
     actor ActorDeinitTest {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         var state: Swift.Int
 
         init()
@@ -631,22 +643,35 @@ enum DeinitVariants {
     }
 }
 enum DependentTypeAccess {
-    struct DependentAccessTest<A> where A: Swift.Collection {
-        var iteratorElement: A.Sequence.Element?
-        var indicesIndex: A.Collection.Index?
-        var subSequenceIndex: A.Collection.Index?
+    struct DependentAccessTest<A> where A: SymbolTestsCore.DependentTypeAccess.OuterProtocol {
+        var middleLeaf: A.OuterProtocol.Middle.MiddleProtocol.Leaf?
+        var innerValue: A.OuterProtocol.Inner.InnerProtocol.Value?
 
-        init(iteratorElement: A.Element?, indicesIndex: A.Index?, subSequenceIndex: A.Index?)
+        init(middleLeaf: A.Middle.Leaf?, innerValue: A.Inner.Value?)
     }
-    struct DeepDependentAccessTest<A> where A: Swift.Collection {
-        var deepElement: A.Sequence.Element?
+    struct DeepDependentAccessTest<A> where A: SymbolTestsCore.DependentTypeAccess.OuterProtocol {
+        var branchFinal: A.OuterProtocol.Middle.MiddleProtocol.Branch.BranchProtocol.Final?
 
-        init(deepElement: A.Element?)
+        init(branchFinal: A.Middle.Branch.Final?)
     }
     struct DependentFunctionTest {
-        func acceptDependent<A>(_: A, iteratorElement: A.Element, indicesElement: A.Index) -> A.SubSequence where A: Swift.Collection
+        func acceptDependent<A>(_: A, middleLeaf: A.Middle.Leaf, innerValue: A.Inner.Value) -> A.Middle.Branch.Final? where A: SymbolTestsCore.DependentTypeAccess.OuterProtocol
     }
-    protocol DependentProtocol where Self.First == Self.Second.Element, Self.Second: Swift.Collection {
+    protocol OuterProtocol where Self.Inner: SymbolTestsCore.DependentTypeAccess.InnerProtocol, Self.Middle: SymbolTestsCore.DependentTypeAccess.MiddleProtocol {
+        associatedtype Middle
+        associatedtype Inner
+    }
+    protocol MiddleProtocol where Self.Branch: SymbolTestsCore.DependentTypeAccess.BranchProtocol {
+        associatedtype Leaf
+        associatedtype Branch
+    }
+    protocol BranchProtocol {
+        associatedtype Final
+    }
+    protocol InnerProtocol {
+        associatedtype Value
+    }
+    protocol DependentProtocol where Self.First == Self.Second.Leaf, Self.Second: SymbolTestsCore.DependentTypeAccess.MiddleProtocol {
         associatedtype First
         associatedtype Second
     }
@@ -690,7 +715,7 @@ enum DiamondInheritance {
 }
 enum DistributedActors {
     actor DistributedActorTest {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         let id: Distributed.LocalTestingActorID
         let actorSystem: Distributed.LocalTestingDistributedActorSystem
 
@@ -714,7 +739,7 @@ enum DistributedActors {
         static func resolve(id: Distributed.LocalTestingActorID, using: Distributed.LocalTestingDistributedActorSystem) throws -> SymbolTestsCore.DistributedActors.DistributedActorTest
     }
     actor GenericDistributedActorTest<A> where A: Swift.Decodable, A: Swift.Encodable {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         let id: Distributed.LocalTestingActorID
         let actorSystem: Distributed.LocalTestingDistributedActorSystem
 
@@ -958,12 +983,14 @@ enum FieldDescriptorVariants {
         init(mutableField: Swift.Int, immutableField: Swift.String, mutableOptional: Swift.Double?, immutableOptional: Swift.Int?)
     }
     class ReferenceFieldTest {
-        weak var weakField: Swift.AnyObject?
-        var unownedField: 
-        var unownedUnsafeField: 
-        var strongField: Swift.AnyObject
-
-        init(reference: Swift.AnyObject)
+        weak var weakVarField: Swift.AnyObject?
+        weak let weakLetField: Swift.AnyObject?
+        unowned var unownedVarField: Swift.AnyObject
+        unowned let unownedLetField: Swift.AnyObject
+        unowned(unsafe) var unownedUnsafeVarField: Swift.AnyObject
+        unowned(unsafe) let unownedUnsafeLetField: Swift.AnyObject
+        var strongVarField: Swift.AnyObject
+        let strongLetField: Swift.AnyObject
     }
     struct MangledNameVariantsTest<A> {
         var concreteInt: Swift.Int
@@ -1064,6 +1091,18 @@ enum FunctionFeatures {
         func acceptAutoclosure(_: @autoclosure () -> Swift.Bool) -> Swift.Bool
         func acceptEscapingAutoclosure(_: @autoclosure () -> Swift.Bool)
         func acceptEscaping(_: () -> ())
+    }
+    struct OwnershipParameterTest {
+        class Box {
+            var value: Swift.Int
+
+            init(_: Swift.Int)
+        }
+        func consumeBox(_: __owned SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box)
+        func twoConsuming(_: __owned SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box, _: __owned SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box)
+        func consumeWithLabel(_: __owned SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box, label: Swift.Int)
+
+        static func staticConsume(_: __owned SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box)
     }
     struct VariadicFunctionTest {
         func format(_: Swift.String, _: Swift.CVarArg...) -> Swift.String
@@ -1286,7 +1325,7 @@ enum Initializers {
         init(value: Swift.Int) throws(SymbolTestsCore.Initializers.CustomInitializerError)
     }
     actor AsyncInitializerActorTest {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         let identifier: Swift.Int
 
         init(identifier: Swift.Int) async
@@ -1378,7 +1417,7 @@ enum NestedFunctions {
 enum NestedGenerics {
     struct OuterGenericTest<A> {
         struct InnerGenericTest<A1> {
-            struct InnerMostGenericTest {
+            struct InnerMostGenericTest<A2> {
                 var outer: A
                 var inner: A1
                 var innerMost: A2
@@ -1976,15 +2015,15 @@ enum WeakUnownedReferences {
         init()
     }
     class UnownedReferenceHolderTest {
-        var unownedReference: 
-        var unownedSafeReference: 
-        var unownedUnsafeReference: 
+        unowned var unownedReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
+        unowned var unownedSafeReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
+        unowned(unsafe) var unownedUnsafeReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
 
         init(target: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest)
     }
     class MixedReferenceHolderTest {
         weak var weakReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest?
-        var unownedReference: 
+        unowned var unownedReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
         var strongReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
 
         init(target: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest)
@@ -2086,6 +2125,8 @@ extension SymbolTestsCore.Actors.CustomGlobalActor: Swift.GlobalActor {
         get
     }
 }
+extension SymbolTestsCore.Actors.GlobalActorIsolatedConformanceTest: @Swift.MainActor SymbolTestsCore.Actors.GlobalActorIsolatedProtocolTest {}
+extension SymbolTestsCore.Actors.GlobalActorIsolatedConformanceTest: @SymbolTestsCore.Actors.CustomGlobalActor SymbolTestsCore.Actors.CustomGlobalActorIsolatedProtocolTest {}
 extension SymbolTestsCore.AssociatedTypeWitnessPatterns.ConcreteWitnessTest: SymbolTestsCore.AssociatedTypeWitnessPatterns.AssociatedPatternProtocol {}
 extension SymbolTestsCore.AssociatedTypeWitnessPatterns.NestedWitnessTest: SymbolTestsCore.AssociatedTypeWitnessPatterns.AssociatedPatternProtocol {}
 extension SymbolTestsCore.AssociatedTypeWitnessPatterns.GenericParameterWitnessTest: SymbolTestsCore.AssociatedTypeWitnessPatterns.AssociatedPatternProtocol {}


### PR DESCRIPTION
## Summary

Roadmap **P2-12** (`Roadmaps/2026-04-13-swiftinterface-dump-improvements.md`) — scoped down to the recoverable subset.

When a conformance is isolated to a global actor (e.g. `extension X: @MainActor P { ... }`), the Swift compiler sets `ProtocolConformanceFlags.hasGlobalActorIsolation` (bit 19) on the conformance descriptor and appends a trailing `TargetGlobalActorReference` carrying the actor type's mangled name and its `GlobalActor` conformance pointer.

- New `GlobalActorReference` model under `Sources/MachOSwiftSection/Models/ProtocolConformance/`. Reads the trailing relative pointer (`type: RelativeDirectPointer<MangledName>` + a raw `RelativeOffset` for the conformance descriptor we don't need to dereference).
- `ProtocolConformance` reads the trailing `GlobalActorReference` after the existing `genericWitnessTable` slot, conditional on the flag.
- `SwiftInterfacePrinter.printExtensionDefinition` emits `@<actor type>` after `@retroactive` and before the protocol name when the conformance carries a global actor reference.
- New `Actors.GlobalActorIsolatedConformanceTest` fixture exercises both `@Swift.MainActor` and a user-defined `@CustomGlobalActor` variant.

## Scope (deferred ABI limitations)

Method-level `@MainActor` and class-level `@MainActor` are **not** recoverable from MachO metadata — see the rationale in the P2-12 section of the roadmap. This PR only handles the conformance-level case, which is the only one with descriptor support in Swift 6.2+.

## Test plan

- [x] `MachOFileInterfaceSnapshotTests/interfaceSnapshot` regenerated and passing
- [ ] `extension Actors.GlobalActorIsolatedConformanceTest: @Swift.MainActor ...GlobalActorIsolatedProtocolTest`
- [ ] `extension Actors.GlobalActorIsolatedConformanceTest: @SymbolTestsCore.Actors.CustomGlobalActor ...CustomGlobalActorIsolatedProtocolTest`
- [ ] `MainActorClosureTest.acceptMainActorClosure` (closure-parameter case, already worked) does not regress