### PR TITLE
feat(SwiftInterface,SwiftDump): emit distributed actor and distributed func

### DIFF
--- a/Sources/SwiftDump/Dumper/ClassDumper.swift
+++ b/Sources/SwiftDump/Dumper/ClassDumper.swift
@@ -42,6 +42,10 @@ package struct ClassDumper<MachO: MachOSwiftSectionRepresentableWithCache>: Type
     package var declaration: SemanticString {
         get async throws {
             if dumped.descriptor.isActor {
+                if isDistributedActor {
+                    Keyword(.distributed)
+                    Space()
+                }
                 Keyword(.actor)
             } else {
                 Keyword(.class)
@@ -59,6 +63,36 @@ package struct ClassDumper<MachO: MachOSwiftSectionRepresentableWithCache>: Type
                 superclass
             }
         }
+    }
+
+    /// The set of inner function nodes of `.distributedThunk` symbols whose class
+    /// context matches this class. Used for both class-level (`distributed actor`)
+    /// and method-level (`distributed func`) keyword emission.
+    private var distributedFunctionNodes: Set<Node> {
+        get throws {
+            guard dumped.descriptor.isActor else { return [] }
+
+            let currentTypeNode = try MetadataReader.demangleContext(for: .type(.class(dumped.descriptor)), in: machO)
+            let currentTypeName = currentTypeNode.print(using: .interfaceTypeBuilderOnly)
+
+            var nodes: Set<Node> = []
+
+            for thunkSymbol in symbolIndexStore.symbols(of: .distributedThunk, in: machO) {
+                let rootNode = thunkSymbol.demangledNode
+                guard let functionNode = rootNode.children.first(where: { $0.kind != .distributedThunk }) else { continue }
+                guard let contextNode = functionNode.children.first else { continue }
+                let thunkTypeName = Node.create(kind: .type, child: contextNode).print(using: .interfaceTypeBuilderOnly)
+                guard thunkTypeName == currentTypeName else { continue }
+                nodes.insert(functionNode)
+            }
+
+            return nodes
+        }
+    }
+
+    private var isDistributedActor: Bool {
+        guard dumped.descriptor.isActor else { return false }
+        return ((try? distributedFunctionNodes) ?? []).isEmpty == false
     }
 
     @SemanticStringBuilder
@@ -173,6 +207,8 @@ package struct ClassDumper<MachO: MachOSwiftSectionRepresentableWithCache>: Type
 
             try await fields
 
+            let distributedFunctionNodes = (try? self.distributedFunctionNodes) ?? []
+
             var methodVisitedNodes: OrderedSet<Node> = []
             let vtableBaseOffset = dumped.vTableDescriptorHeader.map { Int($0.layout.vTableOffset) }
             for (offset, descriptor) in dumped.methodDescriptors.offsetEnumerated() {
@@ -189,11 +225,25 @@ package struct ClassDumper<MachO: MachOSwiftSectionRepresentableWithCache>: Type
 
                 Indent(level: 1)
 
+                // Pre-resolve the method node so we can check distributed status
+                // before deciding which keywords to emit.
+                var resolvedMethodNode: Node? = nil
+                if let symbols = try? descriptor.implementationSymbols(in: machO) {
+                    resolvedMethodNode = try? await validNode(for: symbols, visitedNodes: methodVisitedNodes)
+                }
+
+                let isDistributedMethod: Bool = {
+                    guard descriptor.flags.kind == .method,
+                          let root = resolvedMethodNode,
+                          let functionNode = root.children.first(where: { $0.kind == .function }) else { return false }
+                    return distributedFunctionNodes.contains(functionNode)
+                }()
+
                 dumpMethodKind(for: descriptor)
 
-                dumpMethodKeyword(for: descriptor)
+                dumpMethodKeyword(for: descriptor, isDistributed: isDistributedMethod)
 
-                try await dumpMethodDeclaration(for: descriptor, visitedNodes: &methodVisitedNodes)
+                try await dumpMethodDeclaration(for: descriptor, resolvedNode: resolvedMethodNode, visitedNodes: &methodVisitedNodes)
 
                 if offset.isEnd {
                     BreakLine()
@@ -371,7 +421,7 @@ package struct ClassDumper<MachO: MachOSwiftSectionRepresentableWithCache>: Type
     }
 
     @SemanticStringBuilder
-    private func dumpMethodKeyword(for descriptor: MethodDescriptor) -> SemanticString {
+    private func dumpMethodKeyword(for descriptor: MethodDescriptor, isDistributed: Bool = false) -> SemanticString {
         if !descriptor.flags.isInstance, descriptor.flags.kind != .`init` {
             Keyword(.static)
             Space()
@@ -383,14 +433,27 @@ package struct ClassDumper<MachO: MachOSwiftSectionRepresentableWithCache>: Type
         }
 
         if descriptor.flags.kind == .method {
+            if isDistributed {
+                Keyword(.distributed)
+                Space()
+            }
             Keyword(.func)
             Space()
         }
     }
 
     @SemanticStringBuilder
-    private func dumpMethodDeclaration(for descriptor: MethodDescriptor, visitedNodes: inout OrderedSet<Node>) async throws -> SemanticString {
-        if let symbols = try? descriptor.implementationSymbols(in: machO), let node = try await validNode(for: symbols, visitedNodes: visitedNodes) {
+    private func dumpMethodDeclaration(for descriptor: MethodDescriptor, resolvedNode: Node? = nil, visitedNodes: inout OrderedSet<Node>) async throws -> SemanticString {
+        let node: Node?
+        if let resolvedNode {
+            node = resolvedNode
+        } else if let symbols = try? descriptor.implementationSymbols(in: machO) {
+            node = try await validNode(for: symbols, visitedNodes: visitedNodes)
+        } else {
+            node = nil
+        }
+
+        if let node {
             try await demangleResolver.resolve(for: node)
             _ = visitedNodes.append(node)
         } else if !descriptor.implementation.isNull {

--- a/Sources/SwiftDump/Extensions/Keyword+Swift.swift
+++ b/Sources/SwiftDump/Extensions/Keyword+Swift.swift
@@ -9,6 +9,7 @@ extension Keyword {
         case `actor`
         case `struct`
         case `enum`
+        case distributed
         case `lazy`
         case `weak`
         case `unowned`

--- a/Sources/SwiftDump/SwiftAttribute.swift
+++ b/Sources/SwiftDump/SwiftAttribute.swift
@@ -14,6 +14,7 @@ public enum SwiftAttribute: Int, Comparable, Sendable, CaseIterable {
     case objc
     case nonobjc
     case dynamic
+    case distributed
 
     // Type-level (from conformance: conforms to GlobalActor)
     case globalActor
@@ -35,6 +36,7 @@ public enum SwiftAttribute: Int, Comparable, Sendable, CaseIterable {
         case .objc: return "@objc"
         case .nonobjc: return "@nonobjc"
         case .dynamic: return "dynamic"
+        case .distributed: return "distributed"
         case .globalActor: return "@globalActor"
         case .retroactive: return "@retroactive"
         }
@@ -50,6 +52,7 @@ public enum SwiftAttribute: Int, Comparable, Sendable, CaseIterable {
         case .objc: return .atObjc
         case .nonobjc: return .atNonobjc
         case .dynamic: return .dynamic
+        case .distributed: return .distributed
         case .globalActor: return .atGlobalActor
         case .retroactive: return .atRetroactive
         }

--- a/Sources/SwiftInterface/Components/Definitions/TypeDefinition.swift
+++ b/Sources/SwiftInterface/Components/Definitions/TypeDefinition.swift
@@ -344,6 +344,7 @@ public final class TypeDefinition: Definition {
         let thunkKindsAndAttributes: [(Node.Kind, SwiftAttribute)] = [
             (.objCAttribute, .objc),
             (.nonObjCAttribute, .nonobjc),
+            (.distributedThunk, .distributed),
         ]
 
         for (thunkKind, attribute) in thunkKindsAndAttributes {

--- a/Tests/SwiftInterfaceTests/Snapshots/__Snapshots__/MachOFileInterfaceSnapshotTests/interfaceSnapshot.1.txt
+++ b/Tests/SwiftInterfaceTests/Snapshots/__Snapshots__/MachOFileInterfaceSnapshotTests/interfaceSnapshot.1.txt
@@ -52,7 +52,7 @@ enum AccessLevels {
 }
 enum Actors {
     actor ActorTest {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         var state: Swift.Int
 
         var unownedExecutor: Swift.UnownedSerialExecutor {
@@ -65,7 +65,7 @@ enum Actors {
     }
     @globalActor
     actor CustomGlobalActor {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
 
         var unownedExecutor: Swift.UnownedSerialExecutor {
             get
@@ -83,6 +83,18 @@ enum Actors {
 
         func nonisolatedMethod() -> Swift.String
         func method() -> Swift.Int
+    }
+    class GlobalActorIsolatedConformanceTest {
+        init()
+
+        func customIsolatedRequirement()
+        func isolatedRequirement()
+    }
+    protocol GlobalActorIsolatedProtocolTest {
+        func isolatedRequirement()
+    }
+    protocol CustomGlobalActorIsolatedProtocolTest {
+        func customIsolatedRequirement()
     }
 }
 enum AssociatedTypeWitnessPatterns {
@@ -615,7 +627,7 @@ enum DeinitVariants {
         init()
     }
     actor ActorDeinitTest {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         var state: Swift.Int
 
         init()
@@ -631,22 +643,35 @@ enum DeinitVariants {
     }
 }
 enum DependentTypeAccess {
-    struct DependentAccessTest<A> where A: Swift.Collection {
-        var iteratorElement: A.Sequence.Element?
-        var indicesIndex: A.Collection.Index?
-        var subSequenceIndex: A.Collection.Index?
+    struct DependentAccessTest<A> where A: SymbolTestsCore.DependentTypeAccess.OuterProtocol {
+        var middleLeaf: A.OuterProtocol.Middle.MiddleProtocol.Leaf?
+        var innerValue: A.OuterProtocol.Inner.InnerProtocol.Value?
 
-        init(iteratorElement: A.Element?, indicesIndex: A.Index?, subSequenceIndex: A.Index?)
+        init(middleLeaf: A.Middle.Leaf?, innerValue: A.Inner.Value?)
     }
-    struct DeepDependentAccessTest<A> where A: Swift.Collection {
-        var deepElement: A.Sequence.Element?
+    struct DeepDependentAccessTest<A> where A: SymbolTestsCore.DependentTypeAccess.OuterProtocol {
+        var branchFinal: A.OuterProtocol.Middle.MiddleProtocol.Branch.BranchProtocol.Final?
 
-        init(deepElement: A.Element?)
+        init(branchFinal: A.Middle.Branch.Final?)
     }
     struct DependentFunctionTest {
-        func acceptDependent<A>(_: A, iteratorElement: A.Element, indicesElement: A.Index) -> A.SubSequence where A: Swift.Collection
+        func acceptDependent<A>(_: A, middleLeaf: A.Middle.Leaf, innerValue: A.Inner.Value) -> A.Middle.Branch.Final? where A: SymbolTestsCore.DependentTypeAccess.OuterProtocol
     }
-    protocol DependentProtocol where Self.First == Self.Second.Element, Self.Second: Swift.Collection {
+    protocol OuterProtocol where Self.Inner: SymbolTestsCore.DependentTypeAccess.InnerProtocol, Self.Middle: SymbolTestsCore.DependentTypeAccess.MiddleProtocol {
+        associatedtype Middle
+        associatedtype Inner
+    }
+    protocol MiddleProtocol where Self.Branch: SymbolTestsCore.DependentTypeAccess.BranchProtocol {
+        associatedtype Leaf
+        associatedtype Branch
+    }
+    protocol BranchProtocol {
+        associatedtype Final
+    }
+    protocol InnerProtocol {
+        associatedtype Value
+    }
+    protocol DependentProtocol where Self.First == Self.Second.Leaf, Self.Second: SymbolTestsCore.DependentTypeAccess.MiddleProtocol {
         associatedtype First
         associatedtype Second
     }
@@ -689,8 +714,8 @@ enum DiamondInheritance {
     }
 }
 enum DistributedActors {
-    actor DistributedActorTest {
-        var $defaultActor: 
+    distributed actor DistributedActorTest {
+        var $defaultActor: Builtin.DefaultActorStorage
         let id: Distributed.LocalTestingActorID
         let actorSystem: Distributed.LocalTestingDistributedActorSystem
 
@@ -707,14 +732,14 @@ enum DistributedActors {
             get
         }
 
-        func remoteMethod(value: Swift.Int) -> Swift.Int
-        func remoteThrowingMethod() throws -> Swift.String
-        func parameterizedMethod(label: Swift.String, count: Swift.Int) -> Swift.String
+        distributed func remoteMethod(value: Swift.Int) -> Swift.Int
+        distributed func remoteThrowingMethod() throws -> Swift.String
+        distributed func parameterizedMethod(label: Swift.String, count: Swift.Int) -> Swift.String
 
         static func resolve(id: Distributed.LocalTestingActorID, using: Distributed.LocalTestingDistributedActorSystem) throws -> SymbolTestsCore.DistributedActors.DistributedActorTest
     }
-    actor GenericDistributedActorTest<A> where A: Swift.Decodable, A: Swift.Encodable {
-        var $defaultActor: 
+    distributed actor GenericDistributedActorTest<A> where A: Swift.Decodable, A: Swift.Encodable {
+        var $defaultActor: Builtin.DefaultActorStorage
         let id: Distributed.LocalTestingActorID
         let actorSystem: Distributed.LocalTestingDistributedActorSystem
 
@@ -727,7 +752,7 @@ enum DistributedActors {
             get
         }
 
-        func process(element: A) -> A
+        distributed func process(element: A) -> A
 
         static func resolve(id: Distributed.LocalTestingActorID, using: Distributed.LocalTestingDistributedActorSystem) throws -> SymbolTestsCore.DistributedActors.GenericDistributedActorTest<A>
     }
@@ -958,12 +983,14 @@ enum FieldDescriptorVariants {
         init(mutableField: Swift.Int, immutableField: Swift.String, mutableOptional: Swift.Double?, immutableOptional: Swift.Int?)
     }
     class ReferenceFieldTest {
-        weak var weakField: Swift.AnyObject?
-        var unownedField: 
-        var unownedUnsafeField: 
-        var strongField: Swift.AnyObject
-
-        init(reference: Swift.AnyObject)
+        weak var weakVarField: Swift.AnyObject?
+        weak let weakLetField: Swift.AnyObject?
+        unowned var unownedVarField: Swift.AnyObject
+        unowned let unownedLetField: Swift.AnyObject
+        unowned(unsafe) var unownedUnsafeVarField: Swift.AnyObject
+        unowned(unsafe) let unownedUnsafeLetField: Swift.AnyObject
+        var strongVarField: Swift.AnyObject
+        let strongLetField: Swift.AnyObject
     }
     struct MangledNameVariantsTest<A> {
         var concreteInt: Swift.Int
@@ -1064,6 +1091,18 @@ enum FunctionFeatures {
         func acceptAutoclosure(_: @autoclosure () -> Swift.Bool) -> Swift.Bool
         func acceptEscapingAutoclosure(_: @autoclosure () -> Swift.Bool)
         func acceptEscaping(_: () -> ())
+    }
+    struct OwnershipParameterTest {
+        class Box {
+            var value: Swift.Int
+
+            init(_: Swift.Int)
+        }
+        func consumeBox(_: __owned SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box)
+        func twoConsuming(_: __owned SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box, _: __owned SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box)
+        func consumeWithLabel(_: __owned SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box, label: Swift.Int)
+
+        static func staticConsume(_: __owned SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box)
     }
     struct VariadicFunctionTest {
         func format(_: Swift.String, _: Swift.CVarArg...) -> Swift.String
@@ -1286,7 +1325,7 @@ enum Initializers {
         init(value: Swift.Int) throws(SymbolTestsCore.Initializers.CustomInitializerError)
     }
     actor AsyncInitializerActorTest {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         let identifier: Swift.Int
 
         init(identifier: Swift.Int) async
@@ -1378,7 +1417,7 @@ enum NestedFunctions {
 enum NestedGenerics {
     struct OuterGenericTest<A> {
         struct InnerGenericTest<A1> {
-            struct InnerMostGenericTest {
+            struct InnerMostGenericTest<A2> {
                 var outer: A
                 var inner: A1
                 var innerMost: A2
@@ -1976,15 +2015,15 @@ enum WeakUnownedReferences {
         init()
     }
     class UnownedReferenceHolderTest {
-        var unownedReference: 
-        var unownedSafeReference: 
-        var unownedUnsafeReference: 
+        unowned var unownedReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
+        unowned var unownedSafeReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
+        unowned(unsafe) var unownedUnsafeReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
 
         init(target: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest)
     }
     class MixedReferenceHolderTest {
         weak var weakReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest?
-        var unownedReference: 
+        unowned var unownedReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
         var strongReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
 
         init(target: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest)
@@ -2086,6 +2125,8 @@ extension SymbolTestsCore.Actors.CustomGlobalActor: Swift.GlobalActor {
         get
     }
 }
+extension SymbolTestsCore.Actors.GlobalActorIsolatedConformanceTest: SymbolTestsCore.Actors.GlobalActorIsolatedProtocolTest {}
+extension SymbolTestsCore.Actors.GlobalActorIsolatedConformanceTest: SymbolTestsCore.Actors.CustomGlobalActorIsolatedProtocolTest {}
 extension SymbolTestsCore.AssociatedTypeWitnessPatterns.ConcreteWitnessTest: SymbolTestsCore.AssociatedTypeWitnessPatterns.AssociatedPatternProtocol {}
 extension SymbolTestsCore.AssociatedTypeWitnessPatterns.NestedWitnessTest: SymbolTestsCore.AssociatedTypeWitnessPatterns.AssociatedPatternProtocol {}
 extension SymbolTestsCore.AssociatedTypeWitnessPatterns.GenericParameterWitnessTest: SymbolTestsCore.AssociatedTypeWitnessPatterns.AssociatedPatternProtocol {}


### PR DESCRIPTION
## Summary

Roadmap **P2-13** (`Roadmaps/2026-04-13-swiftinterface-dump-improvements.md`).

`public distributed actor X` previously printed as plain `actor X`, and `public distributed func remoteMethod` as plain `func remoteMethod`. Detect both by cross-referencing `.distributedThunk` symbols (mangled `TE` suffix) against the class context.

- Distributed thunks are keyed by the inner function subtree and wrapped in `global(distributedThunk, function)`. Each matching thunk identifies one method that is marked `distributed` at source level; a class with any such thunk is a `distributed actor`.
- `ClassDumper.declaration` emits `distributed ` before `actor` when the class has at least one distributed thunk whose context matches the dumped type name.
- `ClassDumper.body` pre-resolves each method descriptor's node so it can pass an `isDistributed` flag to `dumpMethodKeyword`, and forwards the resolved node to `dumpMethodDeclaration` to avoid a second `validNode` lookup.
- `TypeDefinition.applyThunkAttributes` adds `.distributedThunk → SwiftAttribute.distributed` to the existing thunk-attribute table so member functions in SwiftInterface pick up the modifier via the regular attribute-printing pipeline.
- New `Keyword.Swift.distributed` and `SwiftAttribute.distributed` (rendered as a non-`@`-prefixed keyword like `dynamic`).

ABI limitations for class-level and method-level global actor isolation remain unchanged (see roadmap L-3 / P2-12).

## Test plan

- [x] `MachOFileInterfaceSnapshotTests/interfaceSnapshot` regenerated and passing
- [ ] `DistributedActors.DistributedActorTest` → `public distributed actor`
- [ ] Its `remoteMethod` / `remoteThrowingMethod` / `parameterizedMethod` → `public distributed func`
- [ ] `Actors.ActorTest` (non-distributed) → continues to print as plain `actor`, no `distributed` on members