### PR TITLE
feat(SwiftInterface): dedupe auto-synthesized protocol members

### DIFF
--- a/Sources/SwiftInterface/Components/Definitions/TypeDefinition.swift
+++ b/Sources/SwiftInterface/Components/Definitions/TypeDefinition.swift
@@ -265,6 +265,16 @@ public final class TypeDefinition: Definition {
         // Cross-reference @objc and @nonobjc thunk symbols with built definitions
         applyThunkAttributes(symbolIndexStore: symbolIndexStore, typeName: name, in: machO)
 
+        // P1-10: drop body-side copies of auto-synthesized Equatable / Hashable /
+        // Codable / CaseIterable / RawRepresentable / CodingKey members. The
+        // canonical copy remains on the conformance extension, avoiding the
+        // "same member printed twice with different addresses" duplication.
+        // This must run *after* applyThunkAttributes so that any user-declared
+        // override flagged with an attribute is dropped alongside its body
+        // entry; the extension copy (which carries the same attribute after
+        // its own indexing pass) is the surviving one.
+        deduplicateSynthesizedProtocolMembers()
+
         // Build ordered members list
         let allMembers = OrderedMember.allMembers(from: self)
         if case .class = type {
@@ -442,6 +452,123 @@ public final class TypeDefinition: Definition {
         for definitionIndex in definitions.indices {
             if !definitions[definitionIndex].attributes.contains(attribute) {
                 definitions[definitionIndex].attributes.append(attribute)
+            }
+        }
+    }
+
+    /// Drops body-side copies of members that Swift auto-synthesizes for
+    /// `Equatable` / `Hashable` / `Codable` / `CaseIterable` / `RawRepresentable` /
+    /// `CodingKey` conformances. These members are emitted twice in binary
+    /// metadata — once as a direct entry on the nominal type (which ends up in
+    /// this type's `functions` / `staticFunctions` / `variables`) and once as a
+    /// witness thunk on the protocol conformance descriptor (which ends up in
+    /// the generated conformance extension). The extension copy is the one
+    /// Swift source conventionally shows for these protocols, so we drop the
+    /// body-side copy.
+    ///
+    /// Detection is gated on the type actually conforming to the relevant
+    /// protocol (via `conformingProtocolNames`), and on the member matching
+    /// the canonical synthesized shape (name + label list). A user-written
+    /// override with a compatible signature will also be dropped from the
+    /// body, but the equivalent entry remains visible in the conformance
+    /// extension, so nothing is hidden — the output is just no longer
+    /// duplicated. See roadmap P1-10.
+    private func deduplicateSynthesizedProtocolMembers() {
+        // Precompute the short (unqualified) names of every protocol this
+        // type conforms to, so downstream checks can ignore module qualifiers.
+        var shortProtocolNames: Set<String> = []
+        for protocolName in conformingProtocolNames {
+            if let dotIndex = protocolName.lastIndex(of: ".") {
+                shortProtocolNames.insert(String(protocolName[protocolName.index(after: dotIndex)...]))
+            } else {
+                shortProtocolNames.insert(protocolName)
+            }
+        }
+
+        if shortProtocolNames.isEmpty { return }
+
+        // Returns the argument label list of a member as an array of strings,
+        // with "_" for unnamed parameters. Works on function / constructor /
+        // allocator / getter nodes; returns an empty array if no labelList
+        // node exists (which means the function either takes no parameters
+        // or takes exclusively unnamed parameters — the demangler does not
+        // always emit an explicit labelList for the all-unnamed case).
+        func labels(of node: Node) -> [String] {
+            guard let list = node.first(of: .labelList) else { return [] }
+            return list.children.map { child in
+                if child.kind == .firstElementMarker { return "_" }
+                return child.text ?? "_"
+            }
+        }
+
+        // Hashable implies Equatable, but Swift still emits both conformances,
+        // so we check them independently.
+        //
+        // `==` is the Swift operator name and is uniquely reserved for
+        // Equatable-shaped comparison at source level, so matching on name
+        // alone is safe. The argument labels of `==` are always unnamed
+        // (`_`, `_`) and the demangler elides the labelList in that case,
+        // which is why we cannot gate on a `[_, _]` label shape here.
+        if shortProtocolNames.contains("Equatable") || shortProtocolNames.contains("Hashable") {
+            staticFunctions.removeAll { function in
+                function.name == "=="
+            }
+        }
+
+        if shortProtocolNames.contains("Hashable") {
+            functions.removeAll { function in
+                (function.name == "hash" && labels(of: function.node) == ["into"])
+                    || (function.name == "_rawHashValue" && labels(of: function.node) == ["seed"])
+            }
+            variables.removeAll { variable in
+                variable.name == "hashValue"
+            }
+        }
+
+        if shortProtocolNames.contains("CaseIterable") {
+            staticVariables.removeAll { variable in
+                variable.name == "allCases"
+            }
+        }
+
+        if shortProtocolNames.contains("RawRepresentable") {
+            variables.removeAll { variable in
+                variable.name == "rawValue"
+            }
+            // `init?(rawValue:)` can appear either as an allocator or a constructor
+            // depending on whether the type has its metadata accessor.
+            allocators.removeAll { function in
+                labels(of: function.node) == ["rawValue"]
+            }
+            constructors.removeAll { function in
+                labels(of: function.node) == ["rawValue"]
+            }
+        }
+
+        if shortProtocolNames.contains("Encodable") || shortProtocolNames.contains("Codable") {
+            functions.removeAll { function in
+                function.name == "encode" && labels(of: function.node) == ["to"]
+            }
+        }
+
+        if shortProtocolNames.contains("Decodable") || shortProtocolNames.contains("Codable") {
+            allocators.removeAll { function in
+                labels(of: function.node) == ["from"]
+            }
+            constructors.removeAll { function in
+                labels(of: function.node) == ["from"]
+            }
+        }
+
+        if shortProtocolNames.contains("CodingKey") {
+            variables.removeAll { variable in
+                variable.name == "stringValue" || variable.name == "intValue"
+            }
+            allocators.removeAll { function in
+                labels(of: function.node) == ["stringValue"] || labels(of: function.node) == ["intValue"]
+            }
+            constructors.removeAll { function in
+                labels(of: function.node) == ["stringValue"] || labels(of: function.node) == ["intValue"]
             }
         }
     }

--- a/Tests/SwiftInterfaceTests/Snapshots/__Snapshots__/MachOFileInterfaceSnapshotTests/interfaceSnapshot.1.txt
+++ b/Tests/SwiftInterfaceTests/Snapshots/__Snapshots__/MachOFileInterfaceSnapshotTests/interfaceSnapshot.1.txt
@@ -52,7 +52,7 @@ enum AccessLevels {
 }
 enum Actors {
     actor ActorTest {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         var state: Swift.Int
 
         var unownedExecutor: Swift.UnownedSerialExecutor {
@@ -65,7 +65,7 @@ enum Actors {
     }
     @globalActor
     actor CustomGlobalActor {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
 
         var unownedExecutor: Swift.UnownedSerialExecutor {
             get
@@ -83,6 +83,18 @@ enum Actors {
 
         func nonisolatedMethod() -> Swift.String
         func method() -> Swift.Int
+    }
+    class GlobalActorIsolatedConformanceTest {
+        init()
+
+        func customIsolatedRequirement()
+        func isolatedRequirement()
+    }
+    protocol GlobalActorIsolatedProtocolTest {
+        func isolatedRequirement()
+    }
+    protocol CustomGlobalActorIsolatedProtocolTest {
+        func customIsolatedRequirement()
     }
 }
 enum AssociatedTypeWitnessPatterns {
@@ -361,9 +373,6 @@ enum CodableTests {
         var optionalValue: Swift.Double?
 
         init(identifier: Swift.Int, name: Swift.String, optionalValue: Swift.Double?)
-        init(from: Swift.Decoder) throws
-
-        func encode(to: Swift.Encoder) throws
     }
     struct CustomCodableTest {
         enum CodingKeys {
@@ -374,9 +383,6 @@ enum CodableTests {
         var hiddenCount: Swift.Int
 
         init(displayName: Swift.String, hiddenCount: Swift.Int)
-        init(from: Swift.Decoder) throws
-
-        func encode(to: Swift.Encoder) throws
     }
     class CodableClassTest {
         enum CodingKeys {
@@ -387,9 +393,6 @@ enum CodableTests {
         var label: Swift.String
 
         init(identifier: Swift.Int, label: Swift.String)
-        init(from: Swift.Decoder) throws
-
-        func encode(to: Swift.Encoder) throws
     }
     enum CodableEnumTest {
         enum CodingKeys {
@@ -408,36 +411,16 @@ enum CodableTests {
         case withValue(Swift.Int)
         case withPair(left: Swift.String, right: Swift.Int)
         case empty
-
-        init(from: Swift.Decoder) throws
-
-        func encode(to: Swift.Encoder) throws
     }
     struct GenericCodableTest<A> where A: Swift.Decodable, A: Swift.Encodable {
         enum CodingKeys {
             case element
             case metadata
-
-            init?(stringValue: Swift.String)
-
-            var hashValue: Swift.Int {
-                get
-            }
-            var stringValue: Swift.String {
-                get
-            }
-
-            func hash(into: inout Swift.Hasher)
-
-            static func == (_: SymbolTestsCore.CodableTests.GenericCodableTest<A>.CodingKeys, _: SymbolTestsCore.CodableTests.GenericCodableTest<A>.CodingKeys) -> Swift.Bool
         }
         var element: A
         var metadata: [Swift.String : Swift.String]
 
         init(element: A, metadata: [Swift.String : Swift.String])
-        init(from: Swift.Decoder) throws
-
-        func encode(to: Swift.Encoder) throws
     }
 }
 enum CollectionConformances {
@@ -615,7 +598,7 @@ enum DeinitVariants {
         init()
     }
     actor ActorDeinitTest {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         var state: Swift.Int
 
         init()
@@ -631,22 +614,35 @@ enum DeinitVariants {
     }
 }
 enum DependentTypeAccess {
-    struct DependentAccessTest<A> where A: Swift.Collection {
-        var iteratorElement: A.Sequence.Element?
-        var indicesIndex: A.Collection.Index?
-        var subSequenceIndex: A.Collection.Index?
+    struct DependentAccessTest<A> where A: SymbolTestsCore.DependentTypeAccess.OuterProtocol {
+        var middleLeaf: A.OuterProtocol.Middle.MiddleProtocol.Leaf?
+        var innerValue: A.OuterProtocol.Inner.InnerProtocol.Value?
 
-        init(iteratorElement: A.Element?, indicesIndex: A.Index?, subSequenceIndex: A.Index?)
+        init(middleLeaf: A.Middle.Leaf?, innerValue: A.Inner.Value?)
     }
-    struct DeepDependentAccessTest<A> where A: Swift.Collection {
-        var deepElement: A.Sequence.Element?
+    struct DeepDependentAccessTest<A> where A: SymbolTestsCore.DependentTypeAccess.OuterProtocol {
+        var branchFinal: A.OuterProtocol.Middle.MiddleProtocol.Branch.BranchProtocol.Final?
 
-        init(deepElement: A.Element?)
+        init(branchFinal: A.Middle.Branch.Final?)
     }
     struct DependentFunctionTest {
-        func acceptDependent<A>(_: A, iteratorElement: A.Element, indicesElement: A.Index) -> A.SubSequence where A: Swift.Collection
+        func acceptDependent<A>(_: A, middleLeaf: A.Middle.Leaf, innerValue: A.Inner.Value) -> A.Middle.Branch.Final? where A: SymbolTestsCore.DependentTypeAccess.OuterProtocol
     }
-    protocol DependentProtocol where Self.First == Self.Second.Element, Self.Second: Swift.Collection {
+    protocol OuterProtocol where Self.Inner: SymbolTestsCore.DependentTypeAccess.InnerProtocol, Self.Middle: SymbolTestsCore.DependentTypeAccess.MiddleProtocol {
+        associatedtype Middle
+        associatedtype Inner
+    }
+    protocol MiddleProtocol where Self.Branch: SymbolTestsCore.DependentTypeAccess.BranchProtocol {
+        associatedtype Leaf
+        associatedtype Branch
+    }
+    protocol BranchProtocol {
+        associatedtype Final
+    }
+    protocol InnerProtocol {
+        associatedtype Value
+    }
+    protocol DependentProtocol where Self.First == Self.Second.Leaf, Self.Second: SymbolTestsCore.DependentTypeAccess.MiddleProtocol {
         associatedtype First
         associatedtype Second
     }
@@ -690,16 +686,13 @@ enum DiamondInheritance {
 }
 enum DistributedActors {
     actor DistributedActorTest {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         let id: Distributed.LocalTestingActorID
         let actorSystem: Distributed.LocalTestingDistributedActorSystem
 
         init(actorSystem: Distributed.LocalTestingDistributedActorSystem)
         init(actorSystem: Distributed.LocalTestingDistributedActorSystem)
 
-        var hashValue: Swift.Int {
-            get
-        }
         var nonisolatedProperty: Swift.String {
             get
         }
@@ -714,15 +707,12 @@ enum DistributedActors {
         static func resolve(id: Distributed.LocalTestingActorID, using: Distributed.LocalTestingDistributedActorSystem) throws -> SymbolTestsCore.DistributedActors.DistributedActorTest
     }
     actor GenericDistributedActorTest<A> where A: Swift.Decodable, A: Swift.Encodable {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         let id: Distributed.LocalTestingActorID
         let actorSystem: Distributed.LocalTestingDistributedActorSystem
 
         init(actorSystem: Distributed.LocalTestingDistributedActorSystem)
 
-        var hashValue: Swift.Int {
-            get
-        }
         var unownedExecutor: Swift.UnownedSerialExecutor {
             get
         }
@@ -762,14 +752,6 @@ enum Enums {
         case south
         case east
         case west
-
-        var hashValue: Swift.Int {
-            get
-        }
-
-        func hash(into: inout Swift.Hasher)
-
-        static func == (_: SymbolTestsCore.Enums.NoPayloadEnumTest, _: SymbolTestsCore.Enums.NoPayloadEnumTest) -> Swift.Bool
     }
     enum SinglePayloadEnumTest {
         case value(Swift.String)
@@ -790,12 +772,7 @@ enum Enums {
         case second
         case third
 
-        init?(rawValue: Swift.Int)
-
         var description: Swift.String {
-            get
-        }
-        var rawValue: Swift.Int {
             get
         }
 
@@ -806,35 +783,13 @@ enum Enums {
     enum StringRawValueEnumTest {
         case hello
         case world
-
-        init?(rawValue: Swift.String)
-
-        var rawValue: Swift.String {
-            get
-        }
     }
     enum CaseIterableEnumTest {
         case alpha
         case beta
         case gamma
-
-        init?(rawValue: Swift.String)
-
-        var rawValue: Swift.String {
-            get
-        }
-
-        static var allCases: [SymbolTestsCore.Enums.CaseIterableEnumTest] {
-            get
-        }
     }
-    enum ObjCEnumTest {
-        init?(rawValue: Swift.Int)
-
-        var rawValue: Swift.Int {
-            get
-        }
-    }
+    enum ObjCEnumTest {}
     enum LargeFrozenEnumTest {
         case alpha
         case beta
@@ -846,14 +801,6 @@ enum Enums {
         case theta
         case iota
         case kappa
-
-        var hashValue: Swift.Int {
-            get
-        }
-
-        func hash(into: inout Swift.Hasher)
-
-        static func == (_: SymbolTestsCore.Enums.LargeFrozenEnumTest, _: SymbolTestsCore.Enums.LargeFrozenEnumTest) -> Swift.Bool
     }
     enum GenericPayloadEnumTest<A> {
         case first(A)
@@ -872,14 +819,6 @@ enum ErrorTypes {
         case notFound
         case invalid
         case unknown
-
-        var hashValue: Swift.Int {
-            get
-        }
-
-        func hash(into: inout Swift.Hasher)
-
-        static func == (_: SymbolTestsCore.ErrorTypes.SimpleErrorTest, _: SymbolTestsCore.ErrorTypes.SimpleErrorTest) -> Swift.Bool
     }
     enum AssociatedValueErrorTest {
         case withMessage(Swift.String)
@@ -958,12 +897,14 @@ enum FieldDescriptorVariants {
         init(mutableField: Swift.Int, immutableField: Swift.String, mutableOptional: Swift.Double?, immutableOptional: Swift.Int?)
     }
     class ReferenceFieldTest {
-        weak var weakField: Swift.AnyObject?
-        var unownedField: 
-        var unownedUnsafeField: 
-        var strongField: Swift.AnyObject
-
-        init(reference: Swift.AnyObject)
+        weak var weakVarField: Swift.AnyObject?
+        weak let weakLetField: Swift.AnyObject?
+        unowned var unownedVarField: Swift.AnyObject
+        unowned let unownedLetField: Swift.AnyObject
+        unowned(unsafe) var unownedUnsafeVarField: Swift.AnyObject
+        unowned(unsafe) let unownedUnsafeLetField: Swift.AnyObject
+        var strongVarField: Swift.AnyObject
+        let strongLetField: Swift.AnyObject
     }
     struct MangledNameVariantsTest<A> {
         var concreteInt: Swift.Int
@@ -1064,6 +1005,18 @@ enum FunctionFeatures {
         func acceptAutoclosure(_: @autoclosure () -> Swift.Bool) -> Swift.Bool
         func acceptEscapingAutoclosure(_: @autoclosure () -> Swift.Bool)
         func acceptEscaping(_: () -> ())
+    }
+    struct OwnershipParameterTest {
+        class Box {
+            var value: Swift.Int
+
+            init(_: Swift.Int)
+        }
+        func consumeBox(_: __owned SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box)
+        func twoConsuming(_: __owned SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box, _: __owned SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box)
+        func consumeWithLabel(_: __owned SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box, label: Swift.Int)
+
+        static func staticConsume(_: __owned SymbolTestsCore.FunctionFeatures.OwnershipParameterTest.Box)
     }
     struct VariadicFunctionTest {
         func format(_: Swift.String, _: Swift.CVarArg...) -> Swift.String
@@ -1286,7 +1239,7 @@ enum Initializers {
         init(value: Swift.Int) throws(SymbolTestsCore.Initializers.CustomInitializerError)
     }
     actor AsyncInitializerActorTest {
-        var $defaultActor: 
+        var $defaultActor: Builtin.DefaultActorStorage
         let identifier: Swift.Int
 
         init(identifier: Swift.Int) async
@@ -1334,14 +1287,6 @@ enum MarkerProtocols {
     enum MarkerConformingEnumTest {
         case first
         case second
-
-        var hashValue: Swift.Int {
-            get
-        }
-
-        func hash(into: inout Swift.Hasher)
-
-        static func == (_: SymbolTestsCore.MarkerProtocols.MarkerConformingEnumTest, _: SymbolTestsCore.MarkerProtocols.MarkerConformingEnumTest) -> Swift.Bool
     }
     protocol MarkerProtocolTest {}
     protocol EmptyMarkerProtocolTest {}
@@ -1378,7 +1323,7 @@ enum NestedFunctions {
 enum NestedGenerics {
     struct OuterGenericTest<A> {
         struct InnerGenericTest<A1> {
-            struct InnerMostGenericTest {
+            struct InnerMostGenericTest<A2> {
                 var outer: A
                 var inner: A1
                 var innerMost: A2
@@ -1452,14 +1397,6 @@ enum OpaqueReturnTypes {
     }
     enum UnderlyingPrimaryAssociatedTypeTest<A, B> where A: SymbolTestsCore.Protocols.ProtocolTest, B: SymbolTestsCore.Protocols.ProtocolTest, A.ProtocolTest.Body.ProtocolTest.Body.ProtocolTest.Body.ProtocolTest.Body.ProtocolTest.Body.ProtocolTest.Body == B.ProtocolTest.Body.ProtocolTest.Body.ProtocolTest.Body.ProtocolTest.Body.ProtocolTest.Body.ProtocolTest.Body {
         case none
-
-        var hashValue: Swift.Int {
-            get
-        }
-
-        func hash(into: inout Swift.Hasher)
-
-        static func == (_: SymbolTestsCore.OpaqueReturnTypes.UnderlyingPrimaryAssociatedTypeTest<A, B>, _: SymbolTestsCore.OpaqueReturnTypes.UnderlyingPrimaryAssociatedTypeTest<A, B>) -> Swift.Bool
     }
     struct OpaquePrimaryAssociatedTypeReturnTypeTest {
         var body: some {
@@ -1484,14 +1421,11 @@ enum Operators {
         static func += (_: inout SymbolTestsCore.Operators.OperatorTestType, _: SymbolTestsCore.Operators.OperatorTestType)
         static func < (_: SymbolTestsCore.Operators.OperatorTestType, _: SymbolTestsCore.Operators.OperatorTestType) -> Swift.Bool
         static func <=> (_: SymbolTestsCore.Operators.OperatorTestType, _: SymbolTestsCore.Operators.OperatorTestType) -> Swift.Int
-        static func == (_: SymbolTestsCore.Operators.OperatorTestType, _: SymbolTestsCore.Operators.OperatorTestType) -> Swift.Bool
     }
 }
 enum OptionSetAndRawRepresentable {
     struct OptionSetTest {
         let rawValue: Swift.UInt
-
-        init(rawValue: Swift.UInt)
 
         static let all: SymbolTestsCore.OptionSetAndRawRepresentable.OptionSetTest
         static var first: SymbolTestsCore.OptionSetAndRawRepresentable.OptionSetTest {
@@ -1506,18 +1440,12 @@ enum OptionSetAndRawRepresentable {
     }
     struct StringRawRepresentableTest {
         let rawValue: Swift.String
-
-        init?(rawValue: Swift.String)
     }
     struct IntRawRepresentableTest {
         var rawValue: Swift.Int
-
-        init(rawValue: Swift.Int)
     }
     struct GenericRawRepresentableTest<A> where A: Swift.Hashable {
         var rawValue: A
-
-        init(rawValue: A)
     }
 }
 enum OverloadedMembers {
@@ -1976,15 +1904,15 @@ enum WeakUnownedReferences {
         init()
     }
     class UnownedReferenceHolderTest {
-        var unownedReference: 
-        var unownedSafeReference: 
-        var unownedUnsafeReference: 
+        unowned var unownedReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
+        unowned var unownedSafeReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
+        unowned(unsafe) var unownedUnsafeReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
 
         init(target: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest)
     }
     class MixedReferenceHolderTest {
         weak var weakReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest?
-        var unownedReference: 
+        unowned var unownedReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
         var strongReference: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest
 
         init(target: SymbolTestsCore.WeakUnownedReferences.ReferenceTargetTest)
@@ -2086,6 +2014,8 @@ extension SymbolTestsCore.Actors.CustomGlobalActor: Swift.GlobalActor {
         get
     }
 }
+extension SymbolTestsCore.Actors.GlobalActorIsolatedConformanceTest: SymbolTestsCore.Actors.GlobalActorIsolatedProtocolTest {}
+extension SymbolTestsCore.Actors.GlobalActorIsolatedConformanceTest: SymbolTestsCore.Actors.CustomGlobalActorIsolatedProtocolTest {}
 extension SymbolTestsCore.AssociatedTypeWitnessPatterns.ConcreteWitnessTest: SymbolTestsCore.AssociatedTypeWitnessPatterns.AssociatedPatternProtocol {}
 extension SymbolTestsCore.AssociatedTypeWitnessPatterns.NestedWitnessTest: SymbolTestsCore.AssociatedTypeWitnessPatterns.AssociatedPatternProtocol {}
 extension SymbolTestsCore.AssociatedTypeWitnessPatterns.GenericParameterWitnessTest: SymbolTestsCore.AssociatedTypeWitnessPatterns.AssociatedPatternProtocol {}


### PR DESCRIPTION
## Summary

Roadmap **P1-10** (`Roadmaps/2026-04-13-swiftinterface-dump-improvements.md`).

Swift's compiler emits members of auto-synthesized `Equatable` / `Hashable` / `Codable` / `CaseIterable` / `RawRepresentable` / `CodingKey` conformances both as direct entries on the nominal type and as witness thunks on the conformance descriptor. The dumper previously rendered both copies, producing duplicated `==` / `hash(into:)` / `hashValue` / `init(from:)` / `encode(to:)` / `allCases` / `rawValue` / etc. with different addresses inside the type body **and** inside the conformance extension.

Add `TypeDefinition.deduplicateSynthesizedProtocolMembers()` which, gated on `conformingProtocolNames`, drops the body-side entries matching the canonical synthesized member shape (name + label list where applicable). Called at the end of `index(in:)` so the resulting `orderedMembers` cache reflects the dedup.

### Safety guarantees

- **Stored fields** (`let rawValue`, user-declared properties) are untouched because they live in `fields`, not `variables` — preserves `OptionSetTest.rawValue`, `IntRawRepresentableTest.rawValue`, etc.
- **User-written operators / helpers** on Equatable types (e.g. `OperatorTestType.+/-/*` or `RawValueEnumTest.description / doubled / fromString`) are untouched because matching keys on the specific member name `==` / `hash` / `encode` / etc.
- **`==` matched by name alone** — Swift demangler elides the labelList node entirely when every parameter is unnamed (`(_, _)`), so gating on `labels.count == 2` would miss every synthesized `==`. The operator name is already uniquely reserved by Equatable.

## Test plan

- [x] `MachOFileInterfaceSnapshotTests/interfaceSnapshot` regenerated and passing
- [ ] `NoPayloadEnumTest` body contains only `case` lines, with `==` / `hash(into:)` / `hashValue` / `_rawHashValue` only inside `: Equatable` / `: Hashable` extensions
- [ ] `RawValueEnumTest` keeps user-written `description` / `doubled` / `fromString` in body, but `rawValue` / `init?(rawValue:)` / `==` / `hash` are dropped from body
- [ ] `OperatorTestType.+/-/*/<` etc. preserved
- [ ] `OptionSetTest.rawValue` (stored `let`) preserved