### PR TITLE
ci: filter to SymbolTestsCore fixture tests + bump to macOS 26 + Xcode 26.4

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -16,7 +16,7 @@ jobs:
         # Apple Silicon runners only: MachOFileTests.preferredArchitecture == .arm64.
         # Adding an Intel runner would load a different arch slice and drift snapshots.
         os: [macos-26]
-        xcode-version: ["26.2"]
+        xcode-version: ["26.4"]
     env:
       MACHO_SWIFT_SECTION_SILENT_TEST: 1
       GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -15,8 +15,8 @@ jobs:
       matrix:
         # Apple Silicon runners only: MachOFileTests.preferredArchitecture == .arm64.
         # Adding an Intel runner would load a different arch slice and drift snapshots.
-        os: [macos-15]
-        xcode-version: ["16.3"]
+        os: [macos-26]
+        xcode-version: ["26.2"]
     env:
       MACHO_SWIFT_SECTION_SILENT_TEST: 1
       GH_TOKEN: ${{ github.token }}
@@ -63,10 +63,12 @@ jobs:
         run: |
           swift test \
             -c debug \
-            --build-path .build-test-debug
+            --build-path .build-test-debug \
+            --filter '\.(SymbolTestsCoreDumpSnapshotTests|SymbolTestsCoreInterfaceSnapshotTests|SymbolTestsCoreCoverageInvariantTests|STCoreE2ETests|STCoreTests)(/|$)'
 
       - name: Build and run tests in release mode
         run: |
           swift test \
             -c release \
-            --build-path .build-test-release
+            --build-path .build-test-release \
+            --filter '\.(SymbolTestsCoreDumpSnapshotTests|SymbolTestsCoreInterfaceSnapshotTests|SymbolTestsCoreCoverageInvariantTests|STCoreE2ETests|STCoreTests)(/|$)'

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -54,6 +54,29 @@ jobs:
             SWIFT_VERIFY_EMITTED_MODULE_INTERFACE=NO \
             build
 
+      - name: Normalize SymbolTestsCore fixture path
+        run: |
+          set -eo pipefail
+          expected="Tests/Projects/SymbolTests/DerivedData/SymbolTests/Build/Products/Release/SymbolTestsCore.framework"
+          echo "--- find SymbolTestsCore.framework under DerivedData ---"
+          find Tests/Projects/SymbolTests/DerivedData -name "SymbolTestsCore.framework" -type d 2>/dev/null || true
+          if [ -d "$expected" ]; then
+            echo "Framework already at expected path; nothing to do."
+            exit 0
+          fi
+          # Prefer a Release build product (skip Intermediates and Debug).
+          found=$(find Tests/Projects/SymbolTests/DerivedData -path '*/Build/Products/Release/SymbolTestsCore.framework' -type d 2>/dev/null | head -1)
+          if [ -z "$found" ]; then
+            echo "ERROR: SymbolTestsCore.framework not found at any Build/Products/Release/ path."
+            echo "--- DerivedData top 3 levels ---"
+            find Tests/Projects/SymbolTests/DerivedData -maxdepth 3 -type d
+            exit 1
+          fi
+          mkdir -p "$(dirname "$expected")"
+          ln -sfn "$(realpath "$found")" "$expected"
+          echo "Linked $found -> $expected"
+          ls -la "$expected/Versions/A/SymbolTestsCore"
+
       - name: Upload xcodebuild logs on failure
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -50,6 +50,8 @@ jobs:
             -destination 'generic/platform=macOS' \
             -quiet \
             CODE_SIGNING_ALLOWED=NO \
+            ARCHS=arm64 \
+            SWIFT_VERIFY_EMITTED_MODULE_INTERFACE=NO \
             build
 
       - name: Upload xcodebuild logs on failure

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -49,6 +49,7 @@ jobs:
             -derivedDataPath Tests/Projects/SymbolTests/DerivedData \
             -destination 'generic/platform=macOS' \
             -quiet \
+            CODE_SIGNING_ALLOWED=NO \
             build
 
       - name: Upload xcodebuild logs on failure

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -51,7 +51,6 @@ jobs:
             -quiet \
             CODE_SIGNING_ALLOWED=NO \
             ARCHS=arm64 \
-            SWIFT_VERIFY_EMITTED_MODULE_INTERFACE=NO \
             build
 
       - name: Normalize SymbolTestsCore fixture path

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "26.2"
+          xcode-version: "26.4"
 
       - name: Swift version
         run: swift --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   build-and-release:
     name: Build and publish release
-    runs-on: macos-15
+    runs-on: macos-26
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "16.3"
+          xcode-version: "26.2"
 
       - name: Swift version
         run: swift --version

--- a/Package.swift
+++ b/Package.swift
@@ -227,7 +227,7 @@ extension Package.Dependency {
         ),
         remote: .package(
             url: "https://github.com/MxIris-Reverse-Engineering/swift-demangling",
-            from: "0.1.0"
+            from: "0.1.1"
         )
     )
     

--- a/docs/superpowers/plans/2026-04-18-ci-test-filter.md
+++ b/docs/superpowers/plans/2026-04-18-ci-test-filter.md
@@ -380,3 +380,28 @@ If a step fails, do **not** patch it blindly. Read the failure log, identify roo
 - **Spec coverage:** Filter regex (Tasks 1, 2), env upgrade for `macOS.yml` (Task 2), env upgrade for `release.yml` (Task 3). Fixture build is already in place — explicitly noted in the spec, no task needed.
 - **No placeholders:** Every textual edit is given as a concrete `old_string`/`new_string` pair; the regex is identical across all uses.
 - **Type consistency:** The five test class names are spelled identically in Tasks 1, 2, the commit message, and the PR body. The `--filter` regex is byte-identical in Steps 3 and 4 of Task 2, in Task 1 verification, and in the spec's "Filter test runs" section.
+
+---
+
+## Implementation Outcome (2026-04-18, after CI feedback)
+
+The Task 1-4 commits above landed as planned and pushed to PR #65, but
+the first CI runs surfaced four issues that needed unplanned follow-up
+fixes. All resolved on the same branch, all included in PR #65.
+
+| # | Issue | Fix | Commit |
+|---|---|---|---|
+| 1 | `xcodebuild` failed on missing developer certificate (team `D5Q73692VW`) | Pass `CODE_SIGNING_ALLOWED=NO` build setting to `xcodebuild` | `84e695a` |
+| 2 | `generic/platform=macOS` produced a universal slice; the x86_64 `.swiftinterface` failed verification (CLAUDE.md notes the project is ARM-only) | Add `ARCHS=arm64` (and `SWIFT_VERIFY_EMITTED_MODULE_INTERFACE=NO`, which turned out not to suppress the Xcode-26 explicit-module verifier) | `cdb84a4` |
+| 3 | Swift 6.2.3 in Xcode 26.2 emits a `.swiftinterface` containing `nonisolated(nonsending)` then refuses to verify its own output (compiler bug) | Bump CI Xcode pin from `26.2` to `26.4` (Swift 6.3 fixed it) | `715e330` |
+| 4 | `swift-demangling 0.1.0` (the remote pin) lacks `DemangleOptions.removeReferenceStoragePrefix`, breaking SwiftDump compilation in CI | Bump `Package.swift` pin from `0.1.0` to `0.1.1` (newly published) | `783656d` |
+| 5 | `xcodebuild` on the CI runner emits the fixture at `DerivedData/Build/Products/Release/`, but `MachOFileName.SymbolTestsCore` reads it from `DerivedData/SymbolTests/Build/Products/Release/` (the layout xcodebuild produces locally) | Add a `Normalize SymbolTestsCore fixture path` step that finds the produced framework and symlinks it to the expected path | `90219b1` |
+
+CI on the macos-26 runner with Xcode 26.4 finishes in ~15 minutes and
+runs exactly the five whitelisted suites in both Debug and Release
+configs. No environment-dependent classes leak through.
+
+The `macos-26` runner had Xcode 26.4 preinstalled, so no further
+setup-xcode workaround was needed. The `macOS` workflow had been in
+`disabled_manually` state on origin (since 2025-10-20); it was
+re-enabled during Task 4 to allow the new run to fire.

--- a/docs/superpowers/plans/2026-04-18-ci-test-filter.md
+++ b/docs/superpowers/plans/2026-04-18-ci-test-filter.md
@@ -1,0 +1,361 @@
+# CI Test Filter and macOS 26.2 Upgrade Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restrict CI test runs to four `SymbolTestsCore` fixture test classes and bump both workflows to macOS 26.2 + Xcode 26.2.
+
+**Architecture:** Pure CI configuration change. No source-code edits. Apply a `--filter` regex to `swift test` in `.github/workflows/macOS.yml`, and bump the runner image and Xcode version in both `macOS.yml` and `release.yml`. Verify the regex selects exactly the intended four test classes, then commit each workflow change separately.
+
+**Tech Stack:** GitHub Actions, `xcodebuild`, SwiftPM `swift test --filter`.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-ci-test-filter-design.md`
+
+---
+
+## File Structure
+
+| File | Change |
+|---|---|
+| `.github/workflows/macOS.yml` | Modify `matrix.os`, `matrix.xcode-version`, and the two `swift test` invocations (add `--filter`) |
+| `.github/workflows/release.yml` | Modify `runs-on` and the `Setup Xcode` `xcode-version` |
+
+No new files. No source files touched.
+
+---
+
+## Task 1: Verify the `--filter` regex locally
+
+**Files:** none modified. Verification only.
+
+**Goal:** Confirm the proposed regex matches exactly the four target test classes — `MachOFileDumpSnapshotTests`, `MachOFileInterfaceSnapshotTests`, `STCoreE2ETests`, `STCoreTests` — and nothing else.
+
+- [ ] **Step 1: List every test method that matches the proposed regex**
+
+Run from repo root:
+
+```
+swift test --list-tests --filter '\.(MachOFileDumpSnapshotTests|MachOFileInterfaceSnapshotTests|STCoreE2ETests|STCoreTests)(/|$)' 2>&1 | tee /tmp/macho-filter-check.txt
+```
+
+Expected: A non-empty list containing only fully qualified test IDs whose
+class component is one of:
+
+- `SwiftDumpTests.MachOFileDumpSnapshotTests`
+- `SwiftInterfaceTests.MachOFileInterfaceSnapshotTests`
+- `SwiftInterfaceTests.STCoreE2ETests`
+- `SwiftInterfaceTests.STCoreTests`
+
+If the build step inside `swift test --list-tests` fails because
+`SymbolTestsCore.framework` is missing, run the existing fixture build
+first:
+
+```
+xcodebuild \
+  -project Tests/Projects/SymbolTests/SymbolTests.xcodeproj \
+  -scheme SymbolTestsCore \
+  -configuration Release \
+  -derivedDataPath Tests/Projects/SymbolTests/DerivedData \
+  -destination 'generic/platform=macOS' \
+  build
+```
+
+Then re-run the `--list-tests` command.
+
+- [ ] **Step 2: Confirm `STCoreE2ETests` and `STCoreTests` are both present and distinct**
+
+Run:
+
+```
+grep -E '\.STCoreE2ETests/' /tmp/macho-filter-check.txt | head -3
+grep -E '\.STCoreTests/' /tmp/macho-filter-check.txt | head -3
+```
+
+Expected: Both commands return at least one line each (i.e. the `\b`-style
+`(/|$)` anchor in the regex correctly distinguishes `STCoreTests` from
+`STCoreE2ETests`).
+
+- [ ] **Step 3: Confirm no environment-dependent classes leak through**
+
+Run:
+
+```
+grep -E '\.(DyldCache|XcodeMachOFile|MachOImage)' /tmp/macho-filter-check.txt || echo "no env-dependent classes matched"
+```
+
+Expected output: `no env-dependent classes matched` (i.e. `grep` finds
+nothing).
+
+- [ ] **Step 4: Confirm no other test classes (e.g. unit tests in `MachOSwiftSectionTests`, `MachOSymbolsTests`, `TypeIndexingTests`) leak through**
+
+Run:
+
+```
+awk -F'/' '{print $1}' /tmp/macho-filter-check.txt | sort -u
+```
+
+Expected: Output contains only the four fully qualified class names listed
+in Step 1, with no extras.
+
+If anything other than the four expected classes appears, **stop**: the
+regex is wrong, fix it before continuing. If only the four expected
+classes appear, proceed.
+
+- [ ] **Step 5: No commit — verification only**
+
+Delete `/tmp/macho-filter-check.txt` (optional, just cleanup).
+
+---
+
+## Task 2: Update `.github/workflows/macOS.yml` — runner, Xcode version, and `--filter`
+
+**Files:**
+- Modify: `.github/workflows/macOS.yml` (lines 18, 19, 65-66, 71-72 — exact line numbers may shift; the changes are textual)
+
+**Goal:** Bump `macos-15` → `macos-26`, `"16.3"` → `"26.2"`, and add `--filter` to both `swift test` invocations. Leave the existing `Resolve SPM dependencies`, `Cache SymbolTests DerivedData`, `Build SymbolTestsCore fixture`, and `Upload xcodebuild logs on failure` steps untouched.
+
+- [ ] **Step 1: Bump the matrix runner image**
+
+Apply this edit:
+
+```
+old_string:
+        os: [macos-15]
+new_string:
+        os: [macos-26]
+```
+
+- [ ] **Step 2: Bump the Xcode version**
+
+Apply this edit:
+
+```
+old_string:
+        xcode-version: ["16.3"]
+new_string:
+        xcode-version: ["26.2"]
+```
+
+- [ ] **Step 3: Add `--filter` to the Debug `swift test` step**
+
+Apply this edit:
+
+```
+old_string:
+      - name: Build and run tests in debug mode
+        run: |
+          swift test \
+            -c debug \
+            --build-path .build-test-debug
+new_string:
+      - name: Build and run tests in debug mode
+        run: |
+          swift test \
+            -c debug \
+            --build-path .build-test-debug \
+            --filter '\.(MachOFileDumpSnapshotTests|MachOFileInterfaceSnapshotTests|STCoreE2ETests|STCoreTests)(/|$)'
+```
+
+- [ ] **Step 4: Add `--filter` to the Release `swift test` step**
+
+Apply this edit:
+
+```
+old_string:
+      - name: Build and run tests in release mode
+        run: |
+          swift test \
+            -c release \
+            --build-path .build-test-release
+new_string:
+      - name: Build and run tests in release mode
+        run: |
+          swift test \
+            -c release \
+            --build-path .build-test-release \
+            --filter '\.(MachOFileDumpSnapshotTests|MachOFileInterfaceSnapshotTests|STCoreE2ETests|STCoreTests)(/|$)'
+```
+
+- [ ] **Step 5: Visually inspect the diff**
+
+Run:
+
+```
+git diff .github/workflows/macOS.yml
+```
+
+Expected: Exactly the four textual changes above. No reflowing of unrelated
+lines, no accidental whitespace changes elsewhere.
+
+- [ ] **Step 6: Validate YAML parses**
+
+Run (Python is preinstalled on macOS):
+
+```
+python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/macOS.yml'))" && echo "yaml OK"
+```
+
+Expected output: `yaml OK`. If parsing fails, fix the indentation or
+quoting before continuing.
+
+- [ ] **Step 7: Commit**
+
+```
+git add .github/workflows/macOS.yml
+git commit -m "$(cat <<'EOF'
+ci(macOS): pin to macos-26 + Xcode 26.2 and filter to fixture tests
+
+Restrict swift test runs to the four SymbolTestsCore-based test classes
+(MachOFileDumpSnapshotTests, MachOFileInterfaceSnapshotTests,
+STCoreE2ETests, STCoreTests) so the CI runner only executes tests that
+do not depend on a developer-machine environment.
+
+Spec: docs/superpowers/specs/2026-04-18-ci-test-filter-design.md
+EOF
+)"
+```
+
+---
+
+## Task 3: Update `.github/workflows/release.yml` — runner and Xcode version
+
+**Files:**
+- Modify: `.github/workflows/release.yml:14, 23`
+
+**Goal:** Match the runner and Xcode version of the test workflow. No other changes.
+
+- [ ] **Step 1: Bump the runner image**
+
+Apply this edit:
+
+```
+old_string:
+    runs-on: macos-15
+new_string:
+    runs-on: macos-26
+```
+
+- [ ] **Step 2: Bump the Xcode version**
+
+Apply this edit:
+
+```
+old_string:
+          xcode-version: "16.3"
+new_string:
+          xcode-version: "26.2"
+```
+
+- [ ] **Step 3: Visually inspect the diff**
+
+Run:
+
+```
+git diff .github/workflows/release.yml
+```
+
+Expected: Exactly two changed lines (`macos-15` → `macos-26`,
+`"16.3"` → `"26.2"`). Nothing else.
+
+- [ ] **Step 4: Validate YAML parses**
+
+Run:
+
+```
+python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/release.yml'))" && echo "yaml OK"
+```
+
+Expected output: `yaml OK`.
+
+- [ ] **Step 5: Commit**
+
+```
+git add .github/workflows/release.yml
+git commit -m "$(cat <<'EOF'
+ci(release): bump runner to macos-26 + Xcode 26.2
+
+Aligns the release workflow with the macOS test workflow.
+EOF
+)"
+```
+
+---
+
+## Task 4: Push branch and open PR
+
+**Files:** none modified.
+
+**Goal:** Get the changes onto a remote branch and open a PR so CI runs end-to-end on a real `macos-26` runner.
+
+- [ ] **Step 1: Confirm branch identity and commit list**
+
+Run:
+
+```
+git log --oneline origin/main..HEAD
+```
+
+Expected: Three commits on `chore/ci-only-fixture-tests`:
+
+1. `Add CI test filter and macOS 26.2 upgrade spec`
+2. `ci(macOS): pin to macos-26 + Xcode 26.2 and filter to fixture tests`
+3. `ci(release): bump runner to macos-26 + Xcode 26.2`
+
+(The order of 2 and 3 may differ depending on task ordering; the spec
+commit is required to be first.)
+
+- [ ] **Step 2: Push the branch**
+
+Run:
+
+```
+git push -u origin chore/ci-only-fixture-tests
+```
+
+- [ ] **Step 3: Open the PR**
+
+Run:
+
+```
+gh pr create --title "ci: filter to SymbolTestsCore fixture tests + bump to macOS 26.2" --body "$(cat <<'EOF'
+## Summary
+- Restrict `swift test` runs in `.github/workflows/macOS.yml` to the four
+  `SymbolTestsCore`-based test classes (`MachOFileDumpSnapshotTests`,
+  `MachOFileInterfaceSnapshotTests`, `STCoreE2ETests`, `STCoreTests`).
+  Other tests depend on developer-machine resources (Xcode frameworks,
+  iOS Simulator runtimes, dyld shared cache) that don't exist on the CI
+  runner.
+- Bump both `macOS.yml` and `release.yml` to `macos-26` + Xcode `26.2`.
+
+## Test plan
+- [ ] CI run on this PR completes the `Build SymbolTestsCore fixture` step.
+- [ ] `Build and run tests in debug mode` and `Build and run tests in release mode` each report exactly the four whitelisted test classes (visible in the test log).
+- [ ] No `DyldCache*`, `Xcode*`, `MachOImage*`, or non-snapshot `*DumpTests` classes appear in the test log.
+
+Spec: `docs/superpowers/specs/2026-04-18-ci-test-filter-design.md`
+EOF
+)"
+```
+
+- [ ] **Step 4: Watch the CI run**
+
+Use the URL printed by `gh pr create`, or:
+
+```
+gh pr checks --watch
+```
+
+Expected: Both Debug and Release `swift test` steps pass.
+
+If a step fails, do **not** patch it blindly. Read the failure log,
+identify root cause, and decide whether the fix belongs in this PR
+(adjust filter regex, fix YAML) or is a separate concern (real test
+breakage on macOS 26.2). For test breakage, file a follow-up issue
+rather than disabling the failing test in this PR.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Filter regex (Tasks 1, 2), env upgrade for `macOS.yml` (Task 2), env upgrade for `release.yml` (Task 3). Fixture build is already in place — explicitly noted in the spec, no task needed.
+- **No placeholders:** Every textual edit is given as a concrete `old_string`/`new_string` pair; the regex is identical across all uses.
+- **Type consistency:** The four test class names are spelled identically in Tasks 1, 2, and the PR body. The `--filter` regex is byte-identical in Steps 3 and 4 of Task 2 and in Task 1 verification.

--- a/docs/superpowers/plans/2026-04-18-ci-test-filter.md
+++ b/docs/superpowers/plans/2026-04-18-ci-test-filter.md
@@ -1,8 +1,8 @@
-# CI Test Filter and macOS 26.2 Upgrade Implementation Plan
+# CI Test Filter and macOS 26 Upgrade Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Restrict CI test runs to five `SymbolTestsCore`-based test classes and bump both workflows to macOS 26.2 + Xcode 26.2.
+**Goal:** Restrict CI test runs to five `SymbolTestsCore`-based test classes and bump both workflows to macOS 26 + Xcode 26.4.
 
 **Architecture:** Pure CI configuration change. No source-code edits. Apply a `--filter` regex to `swift test` in `.github/workflows/macOS.yml`, and bump the runner image and Xcode version in both `macOS.yml` and `release.yml`. Verify the regex selects exactly the intended five test classes, then commit each workflow change separately.
 
@@ -137,7 +137,7 @@ Optionally `rm /tmp/macho-all-tests.txt /tmp/macho-filter-check.txt` to clean up
 **Files:**
 - Modify: `.github/workflows/macOS.yml` (4 textual changes; exact line numbers may shift)
 
-**Goal:** Bump `macos-15` → `macos-26`, `"16.3"` → `"26.2"`, and add `--filter` to both `swift test` invocations. Leave the existing `Resolve SPM dependencies`, `Cache SymbolTests DerivedData`, `Build SymbolTestsCore fixture`, and `Upload xcodebuild logs on failure` steps untouched.
+**Goal:** Bump `macos-15` → `macos-26`, `"16.3"` → `"26.4"`, and add `--filter` to both `swift test` invocations. Leave the existing `Resolve SPM dependencies`, `Cache SymbolTests DerivedData`, `Build SymbolTestsCore fixture`, and `Upload xcodebuild logs on failure` steps untouched.
 
 - [ ] **Step 1: Bump the matrix runner image**
 
@@ -158,7 +158,7 @@ Apply this edit:
 old_string:
         xcode-version: ["16.3"]
 new_string:
-        xcode-version: ["26.2"]
+        xcode-version: ["26.4"]
 ```
 
 - [ ] **Step 3: Add `--filter` to the Debug `swift test` step**
@@ -267,7 +267,7 @@ Apply this edit:
 old_string:
           xcode-version: "16.3"
 new_string:
-          xcode-version: "26.2"
+          xcode-version: "26.4"
 ```
 
 - [ ] **Step 3: Visually inspect the diff**
@@ -278,7 +278,7 @@ Run:
 git diff .github/workflows/release.yml
 ```
 
-Expected: Exactly two changed lines (`macos-15` → `macos-26`, `"16.3"` → `"26.2"`). Nothing else.
+Expected: Exactly two changed lines (`macos-15` → `macos-26`, `"16.3"` → `"26.4"`). Nothing else.
 
 - [ ] **Step 4: Validate YAML parses**
 

--- a/docs/superpowers/plans/2026-04-18-ci-test-filter.md
+++ b/docs/superpowers/plans/2026-04-18-ci-test-filter.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Restrict CI test runs to four `SymbolTestsCore` fixture test classes and bump both workflows to macOS 26.2 + Xcode 26.2.
+**Goal:** Restrict CI test runs to five `SymbolTestsCore`-based test classes and bump both workflows to macOS 26.2 + Xcode 26.2.
 
-**Architecture:** Pure CI configuration change. No source-code edits. Apply a `--filter` regex to `swift test` in `.github/workflows/macOS.yml`, and bump the runner image and Xcode version in both `macOS.yml` and `release.yml`. Verify the regex selects exactly the intended four test classes, then commit each workflow change separately.
+**Architecture:** Pure CI configuration change. No source-code edits. Apply a `--filter` regex to `swift test` in `.github/workflows/macOS.yml`, and bump the runner image and Xcode version in both `macOS.yml` and `release.yml`. Verify the regex selects exactly the intended five test classes, then commit each workflow change separately.
 
 **Tech Stack:** GitHub Actions, `xcodebuild`, SwiftPM `swift test --filter`.
 
@@ -27,27 +27,31 @@ No new files. No source files touched.
 
 **Files:** none modified. Verification only.
 
-**Goal:** Confirm the proposed regex matches exactly the four target test classes — `MachOFileDumpSnapshotTests`, `MachOFileInterfaceSnapshotTests`, `STCoreE2ETests`, `STCoreTests` — and nothing else.
+**Goal:** Confirm the proposed regex matches exactly the five target test classes and nothing else:
 
-- [ ] **Step 1: List every test method that matches the proposed regex**
-
-Run from repo root:
-
-```
-swift test --list-tests --filter '\.(MachOFileDumpSnapshotTests|MachOFileInterfaceSnapshotTests|STCoreE2ETests|STCoreTests)(/|$)' 2>&1 | tee /tmp/macho-filter-check.txt
-```
-
-Expected: A non-empty list containing only fully qualified test IDs whose
-class component is one of:
-
-- `SwiftDumpTests.MachOFileDumpSnapshotTests`
-- `SwiftInterfaceTests.MachOFileInterfaceSnapshotTests`
+- `SwiftDumpTests.SymbolTestsCoreDumpSnapshotTests`
+- `SwiftInterfaceTests.SymbolTestsCoreInterfaceSnapshotTests`
+- `SwiftDumpTests.SymbolTestsCoreCoverageInvariantTests`
 - `SwiftInterfaceTests.STCoreE2ETests`
 - `SwiftInterfaceTests.STCoreTests`
 
-If the build step inside `swift test --list-tests` fails because
-`SymbolTestsCore.framework` is missing, run the existing fixture build
-first:
+The proposed regex is:
+
+```
+\.(SymbolTestsCoreDumpSnapshotTests|SymbolTestsCoreInterfaceSnapshotTests|SymbolTestsCoreCoverageInvariantTests|STCoreE2ETests|STCoreTests)(/|$)
+```
+
+Note on tooling: in the current Swift toolchain, `swift test --list-tests` is deprecated and `swift test list` does not accept `--filter`. We therefore enumerate every test ID with `swift test list`, then apply the regex with local `grep -E` to simulate what SwiftPM's `--filter` will admit at CI time.
+
+- [ ] **Step 1: Confirm the SymbolTestsCore fixture framework exists**
+
+Run:
+
+```
+ls Tests/Projects/SymbolTests/DerivedData/SymbolTests/Build/Products/Release/SymbolTestsCore.framework/Versions/A/SymbolTestsCore
+```
+
+Expected: the path lists. If it does not, build it once before continuing:
 
 ```
 xcodebuild \
@@ -59,9 +63,27 @@ xcodebuild \
   build
 ```
 
-Then re-run the `--list-tests` command.
+- [ ] **Step 2: Enumerate every test ID**
 
-- [ ] **Step 2: Confirm `STCoreE2ETests` and `STCoreTests` are both present and distinct**
+Run from repo root (allow up to 10 minutes — SwiftPM may build the entire test target graph on first run):
+
+```
+swift test list 2>&1 | tee /tmp/macho-all-tests.txt
+```
+
+Expected: the file ends with hundreds of lines of the form `<TargetName>.<ClassName>/<methodName>` (plus some build-progress noise lines that the later grep ignores).
+
+- [ ] **Step 3: Apply the proposed regex and capture matches**
+
+Run:
+
+```
+grep -E '\.(SymbolTestsCoreDumpSnapshotTests|SymbolTestsCoreInterfaceSnapshotTests|SymbolTestsCoreCoverageInvariantTests|STCoreE2ETests|STCoreTests)(/|$)' /tmp/macho-all-tests.txt | tee /tmp/macho-filter-check.txt | wc -l
+```
+
+Expected: a non-zero count. Each line in `/tmp/macho-filter-check.txt` should be a fully qualified test ID whose class component is one of the five targets above.
+
+- [ ] **Step 4: Confirm `STCoreE2ETests` and `STCoreTests` are both present and distinct**
 
 Run:
 
@@ -70,11 +92,9 @@ grep -E '\.STCoreE2ETests/' /tmp/macho-filter-check.txt | head -3
 grep -E '\.STCoreTests/' /tmp/macho-filter-check.txt | head -3
 ```
 
-Expected: Both commands return at least one line each (i.e. the `\b`-style
-`(/|$)` anchor in the regex correctly distinguishes `STCoreTests` from
-`STCoreE2ETests`).
+Expected: Both commands return at least one line each (the `(/|$)` anchor in the regex correctly distinguishes `STCoreTests` from `STCoreE2ETests`).
 
-- [ ] **Step 3: Confirm no environment-dependent classes leak through**
+- [ ] **Step 5: Confirm no environment-dependent classes leak through**
 
 Run:
 
@@ -82,10 +102,9 @@ Run:
 grep -E '\.(DyldCache|XcodeMachOFile|MachOImage)' /tmp/macho-filter-check.txt || echo "no env-dependent classes matched"
 ```
 
-Expected output: `no env-dependent classes matched` (i.e. `grep` finds
-nothing).
+Expected output: `no env-dependent classes matched`.
 
-- [ ] **Step 4: Confirm no other test classes (e.g. unit tests in `MachOSwiftSectionTests`, `MachOSymbolsTests`, `TypeIndexingTests`) leak through**
+- [ ] **Step 6: Confirm the unique class set is exactly the five expected**
 
 Run:
 
@@ -93,23 +112,30 @@ Run:
 awk -F'/' '{print $1}' /tmp/macho-filter-check.txt | sort -u
 ```
 
-Expected: Output contains only the four fully qualified class names listed
-in Step 1, with no extras.
+Expected output (exactly these five lines, possibly in a different sort order — they will sort alphabetically):
 
-If anything other than the four expected classes appears, **stop**: the
-regex is wrong, fix it before continuing. If only the four expected
-classes appear, proceed.
+```
+SwiftDumpTests.SymbolTestsCoreCoverageInvariantTests
+SwiftDumpTests.SymbolTestsCoreDumpSnapshotTests
+SwiftInterfaceTests.STCoreE2ETests
+SwiftInterfaceTests.STCoreTests
+SwiftInterfaceTests.SymbolTestsCoreInterfaceSnapshotTests
+```
 
-- [ ] **Step 5: No commit — verification only**
+If any other class name appears, **stop**: the regex is admitting something it should not. Report and let the controller decide.
 
-Delete `/tmp/macho-filter-check.txt` (optional, just cleanup).
+If a name from the expected set is missing, **stop**: the regex is too restrictive. Report.
+
+- [ ] **Step 7: No commit — verification only**
+
+Optionally `rm /tmp/macho-all-tests.txt /tmp/macho-filter-check.txt` to clean up.
 
 ---
 
 ## Task 2: Update `.github/workflows/macOS.yml` — runner, Xcode version, and `--filter`
 
 **Files:**
-- Modify: `.github/workflows/macOS.yml` (lines 18, 19, 65-66, 71-72 — exact line numbers may shift; the changes are textual)
+- Modify: `.github/workflows/macOS.yml` (4 textual changes; exact line numbers may shift)
 
 **Goal:** Bump `macos-15` → `macos-26`, `"16.3"` → `"26.2"`, and add `--filter` to both `swift test` invocations. Leave the existing `Resolve SPM dependencies`, `Cache SymbolTests DerivedData`, `Build SymbolTestsCore fixture`, and `Upload xcodebuild logs on failure` steps untouched.
 
@@ -152,7 +178,7 @@ new_string:
           swift test \
             -c debug \
             --build-path .build-test-debug \
-            --filter '\.(MachOFileDumpSnapshotTests|MachOFileInterfaceSnapshotTests|STCoreE2ETests|STCoreTests)(/|$)'
+            --filter '\.(SymbolTestsCoreDumpSnapshotTests|SymbolTestsCoreInterfaceSnapshotTests|SymbolTestsCoreCoverageInvariantTests|STCoreE2ETests|STCoreTests)(/|$)'
 ```
 
 - [ ] **Step 4: Add `--filter` to the Release `swift test` step**
@@ -172,7 +198,7 @@ new_string:
           swift test \
             -c release \
             --build-path .build-test-release \
-            --filter '\.(MachOFileDumpSnapshotTests|MachOFileInterfaceSnapshotTests|STCoreE2ETests|STCoreTests)(/|$)'
+            --filter '\.(SymbolTestsCoreDumpSnapshotTests|SymbolTestsCoreInterfaceSnapshotTests|SymbolTestsCoreCoverageInvariantTests|STCoreE2ETests|STCoreTests)(/|$)'
 ```
 
 - [ ] **Step 5: Visually inspect the diff**
@@ -183,8 +209,7 @@ Run:
 git diff .github/workflows/macOS.yml
 ```
 
-Expected: Exactly the four textual changes above. No reflowing of unrelated
-lines, no accidental whitespace changes elsewhere.
+Expected: Exactly the four textual changes above. No reflowing of unrelated lines, no accidental whitespace changes elsewhere.
 
 - [ ] **Step 6: Validate YAML parses**
 
@@ -194,8 +219,7 @@ Run (Python is preinstalled on macOS):
 python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/macOS.yml'))" && echo "yaml OK"
 ```
 
-Expected output: `yaml OK`. If parsing fails, fix the indentation or
-quoting before continuing.
+Expected output: `yaml OK`. If parsing fails, fix the indentation or quoting before continuing.
 
 - [ ] **Step 7: Commit**
 
@@ -204,10 +228,11 @@ git add .github/workflows/macOS.yml
 git commit -m "$(cat <<'EOF'
 ci(macOS): pin to macos-26 + Xcode 26.2 and filter to fixture tests
 
-Restrict swift test runs to the four SymbolTestsCore-based test classes
-(MachOFileDumpSnapshotTests, MachOFileInterfaceSnapshotTests,
-STCoreE2ETests, STCoreTests) so the CI runner only executes tests that
-do not depend on a developer-machine environment.
+Restrict swift test runs to the five SymbolTestsCore-based test classes
+(SymbolTestsCoreDumpSnapshotTests, SymbolTestsCoreInterfaceSnapshotTests,
+SymbolTestsCoreCoverageInvariantTests, STCoreE2ETests, STCoreTests) so
+the CI runner only executes tests that do not depend on a developer-
+machine environment.
 
 Spec: docs/superpowers/specs/2026-04-18-ci-test-filter-design.md
 EOF
@@ -219,7 +244,7 @@ EOF
 ## Task 3: Update `.github/workflows/release.yml` — runner and Xcode version
 
 **Files:**
-- Modify: `.github/workflows/release.yml:14, 23`
+- Modify: `.github/workflows/release.yml` (2 textual changes)
 
 **Goal:** Match the runner and Xcode version of the test workflow. No other changes.
 
@@ -253,8 +278,7 @@ Run:
 git diff .github/workflows/release.yml
 ```
 
-Expected: Exactly two changed lines (`macos-15` → `macos-26`,
-`"16.3"` → `"26.2"`). Nothing else.
+Expected: Exactly two changed lines (`macos-15` → `macos-26`, `"16.3"` → `"26.2"`). Nothing else.
 
 - [ ] **Step 4: Validate YAML parses**
 
@@ -294,14 +318,14 @@ Run:
 git log --oneline origin/main..HEAD
 ```
 
-Expected: Three commits on `chore/ci-only-fixture-tests`:
+Expected: At least four commits on `chore/ci-only-fixture-tests`:
 
-1. `Add CI test filter and macOS 26.2 upgrade spec`
-2. `ci(macOS): pin to macos-26 + Xcode 26.2 and filter to fixture tests`
-3. `ci(release): bump runner to macos-26 + Xcode 26.2`
+1. `Add CI test filter and macOS 26.2 upgrade spec` (initial spec)
+2. `Refine CI filter spec to current state and add implementation plan` (spec correction + plan)
+3. `ci(macOS): pin to macos-26 + Xcode 26.2 and filter to fixture tests`
+4. `ci(release): bump runner to macos-26 + Xcode 26.2`
 
-(The order of 2 and 3 may differ depending on task ordering; the spec
-commit is required to be first.)
+Plus possibly an extra spec/plan correction commit (e.g. the regex update from four to five classes once that landed).
 
 - [ ] **Step 2: Push the branch**
 
@@ -318,9 +342,10 @@ Run:
 ```
 gh pr create --title "ci: filter to SymbolTestsCore fixture tests + bump to macOS 26.2" --body "$(cat <<'EOF'
 ## Summary
-- Restrict `swift test` runs in `.github/workflows/macOS.yml` to the four
-  `SymbolTestsCore`-based test classes (`MachOFileDumpSnapshotTests`,
-  `MachOFileInterfaceSnapshotTests`, `STCoreE2ETests`, `STCoreTests`).
+- Restrict `swift test` runs in `.github/workflows/macOS.yml` to the five
+  `SymbolTestsCore`-based test classes (`SymbolTestsCoreDumpSnapshotTests`,
+  `SymbolTestsCoreInterfaceSnapshotTests`,
+  `SymbolTestsCoreCoverageInvariantTests`, `STCoreE2ETests`, `STCoreTests`).
   Other tests depend on developer-machine resources (Xcode frameworks,
   iOS Simulator runtimes, dyld shared cache) that don't exist on the CI
   runner.
@@ -328,7 +353,7 @@ gh pr create --title "ci: filter to SymbolTestsCore fixture tests + bump to macO
 
 ## Test plan
 - [ ] CI run on this PR completes the `Build SymbolTestsCore fixture` step.
-- [ ] `Build and run tests in debug mode` and `Build and run tests in release mode` each report exactly the four whitelisted test classes (visible in the test log).
+- [ ] `Build and run tests in debug mode` and `Build and run tests in release mode` each report exactly the five whitelisted test classes (visible in the test log).
 - [ ] No `DyldCache*`, `Xcode*`, `MachOImage*`, or non-snapshot `*DumpTests` classes appear in the test log.
 
 Spec: `docs/superpowers/specs/2026-04-18-ci-test-filter-design.md`
@@ -346,11 +371,7 @@ gh pr checks --watch
 
 Expected: Both Debug and Release `swift test` steps pass.
 
-If a step fails, do **not** patch it blindly. Read the failure log,
-identify root cause, and decide whether the fix belongs in this PR
-(adjust filter regex, fix YAML) or is a separate concern (real test
-breakage on macOS 26.2). For test breakage, file a follow-up issue
-rather than disabling the failing test in this PR.
+If a step fails, do **not** patch it blindly. Read the failure log, identify root cause, and decide whether the fix belongs in this PR (adjust filter regex, fix YAML) or is a separate concern (real test breakage on macOS 26.2). For test breakage, file a follow-up issue rather than disabling the failing test in this PR.
 
 ---
 
@@ -358,4 +379,4 @@ rather than disabling the failing test in this PR.
 
 - **Spec coverage:** Filter regex (Tasks 1, 2), env upgrade for `macOS.yml` (Task 2), env upgrade for `release.yml` (Task 3). Fixture build is already in place — explicitly noted in the spec, no task needed.
 - **No placeholders:** Every textual edit is given as a concrete `old_string`/`new_string` pair; the regex is identical across all uses.
-- **Type consistency:** The four test class names are spelled identically in Tasks 1, 2, and the PR body. The `--filter` regex is byte-identical in Steps 3 and 4 of Task 2 and in Task 1 verification.
+- **Type consistency:** The five test class names are spelled identically in Tasks 1, 2, the commit message, and the PR body. The `--filter` regex is byte-identical in Steps 3 and 4 of Task 2, in Task 1 verification, and in the spec's "Filter test runs" section.

--- a/docs/superpowers/specs/2026-04-18-ci-test-filter-design.md
+++ b/docs/superpowers/specs/2026-04-18-ci-test-filter-design.md
@@ -59,32 +59,18 @@ excluded from CI runs. Those tests remain fully functional locally.
 
 ### 1. Build the fixture
 
-Add a step before `swift test` that builds `SymbolTestsCore.framework` using
-`xcodebuild`, writing to the exact `DerivedData` path that
+The `Build SymbolTestsCore fixture` step is already present on `main` (along
+with `Resolve SPM dependencies`, `Cache SymbolTests DerivedData`, and
+`Upload xcodebuild logs on failure`). It uses `-derivedDataPath
+Tests/Projects/SymbolTests/DerivedData`, which matches the path
 `MachOFileName.SymbolTestsCore` (in
-`Sources/MachOTestingSupport/MachOFileName.swift`) expects:
-
-```yaml
-- name: Build SymbolTestsCore fixture
-  run: |
-    xcodebuild \
-      -project Tests/Projects/SymbolTests/SymbolTests.xcodeproj \
-      -scheme SymbolTestsCore \
-      -configuration Release \
-      -derivedDataPath Tests/Projects/SymbolTests/DerivedData \
-      -destination 'generic/platform=macOS' \
-      build
-```
-
-`MachOFileName.SymbolTestsCore.rawValue` is a path relative to
-`#filePath` inside `MachOTestingSupport`:
+`Sources/MachOTestingSupport/MachOFileName.swift`) resolves:
 
 ```
 ../../Tests/Projects/SymbolTests/DerivedData/SymbolTests/Build/Products/Release/SymbolTestsCore.framework/Versions/A/SymbolTestsCore
 ```
 
-The `-derivedDataPath` value above resolves to the same `Release` product
-location. No test-code changes are required.
+No change is needed for fixture construction.
 
 ### 2. Filter test runs
 
@@ -109,7 +95,6 @@ Both workflows move to macOS 26.2 + Xcode 26.2.
 
 - `matrix.os`: `macos-15` → `macos-26`
 - `matrix.xcode-version`: `"16.3"` → `"26.2"`
-- `matrix.release`: `2024` → `2026`
 
 `.github/workflows/release.yml`:
 
@@ -118,62 +103,20 @@ Both workflows move to macOS 26.2 + Xcode 26.2.
 
 ## Final workflow shape
 
-```yaml
-# .github/workflows/macOS.yml
-name: macOS
+The `macOS.yml` workflow keeps its existing structure (Resolve SPM,
+Cache DerivedData, Build SymbolTestsCore fixture, Upload logs on failure,
+Build and run tests). Only three lines change:
 
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-
-jobs:
-  macos_test:
-    name: Execute tests on macOS
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-26]
-        xcode-version: ["26.2"]
-        release: [2026]
-    runs-on: ${{ matrix.os }}
-    env:
-      MACHO_SWIFT_SECTION_SILENT_TEST: 1
-      GH_TOKEN: ${{ github.token }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: ${{ matrix.xcode-version }}
-      - name: Swift version
-        run: swift --version
-      - name: Build SymbolTestsCore fixture
-        run: |
-          xcodebuild \
-            -project Tests/Projects/SymbolTests/SymbolTests.xcodeproj \
-            -scheme SymbolTestsCore \
-            -configuration Release \
-            -derivedDataPath Tests/Projects/SymbolTests/DerivedData \
-            -destination 'generic/platform=macOS' \
-            build
-      - name: Build and run tests in debug mode
-        run: |
-          swift test \
-            -c debug \
-            --build-path .build-test-debug \
-            --filter '\.(MachOFileDumpSnapshotTests|MachOFileInterfaceSnapshotTests|STCoreE2ETests|STCoreTests)(/|$)'
-      - name: Build and run tests in release mode
-        run: |
-          swift test \
-            -c release \
-            --build-path .build-test-release \
-            --filter '\.(MachOFileDumpSnapshotTests|MachOFileInterfaceSnapshotTests|STCoreE2ETests|STCoreTests)(/|$)'
-```
+- `matrix.os: macos-15` → `matrix.os: macos-26`
+- `matrix.xcode-version: "16.3"` → `matrix.xcode-version: "26.2"`
+- Both `swift test` invocations gain a single `--filter` argument:
+  `'\.(MachOFileDumpSnapshotTests|MachOFileInterfaceSnapshotTests|STCoreE2ETests|STCoreTests)(/|$)'`
 
 `release.yml` keeps its existing shape, with only the runner and Xcode
-version bumped.
+version bumped:
+
+- `runs-on: macos-15` → `runs-on: macos-26`
+- `xcode-version: "16.3"` → `xcode-version: "26.2"`
 
 ## Trade-offs
 

--- a/docs/superpowers/specs/2026-04-18-ci-test-filter-design.md
+++ b/docs/superpowers/specs/2026-04-18-ci-test-filter-design.md
@@ -1,0 +1,206 @@
+# CI Test Filter and Environment Upgrade
+
+**Date:** 2026-04-18
+**Status:** Approved, pending implementation
+
+## Problem
+
+The GitHub Actions `macOS` workflow runs `swift test` against the entire test
+suite. Most test classes rely on resources that only exist on a developer
+machine — installed Xcode frameworks (`/Applications/Xcode.app/...`), iOS
+Simulator runtimes, the on-device dyld shared cache, runtime-loaded images, and
+user applications. On a CI runner these paths do not exist, so those tests
+either fail or are meaningless. Running them wastes time and masks real
+signal.
+
+There are also tests that can run on CI but require a build artifact that is
+not in git: `SymbolTestsCore.framework`. It is produced by the Xcode project
+at `Tests/Projects/SymbolTests/SymbolTests.xcodeproj`, and its `DerivedData`
+directory is listed in `.gitignore`. The current workflow does not build this
+artifact, so even the self-contained fixture tests can't run.
+
+Separately, the workflow pins `macos-15` + Xcode `16.3`. Project requirements
+have moved to macOS 26.2 + Xcode 26.2.
+
+## Goals
+
+- CI runs only the test classes that work without a developer-machine
+  environment.
+- CI builds the `SymbolTestsCore.framework` fixture before running tests.
+- CI and the release workflow both run on `macos-26` + Xcode `26.2`.
+- No changes to test source files — the filter lives in CI configuration only.
+
+## Non-Goals
+
+- Introducing runtime flags, tags, or `.disabled(if:)` traits in test code.
+- Changing which tests exist or how they're organised.
+- Making the blocked tests runnable in CI (e.g. vendoring dyld caches, shipping
+  Xcode frameworks). They remain developer-only.
+- Checking `SymbolTestsCore.framework` into git.
+
+## Scope: Tests that run in CI (whitelist)
+
+Exactly four test classes run in CI. All of them read from
+`SymbolTestsCore.framework`:
+
+| Test class | File | Category |
+|---|---|---|
+| `MachOFileDumpSnapshotTests` | `Tests/SwiftDumpTests/Snapshots/MachOFileDumpSnapshotTests.swift` | Dump snapshot |
+| `MachOFileInterfaceSnapshotTests` | `Tests/SwiftInterfaceTests/Snapshots/MachOFileInterfaceSnapshotTests.swift` | Interface snapshot |
+| `STCoreE2ETests` | `Tests/SwiftInterfaceTests/SymbolTestsCoreE2ETests.swift` | Fixture E2E |
+| `STCoreTests` | `Tests/SwiftInterfaceTests/SymbolTestsCoreIntegrationTests.swift` | Fixture integration |
+
+Every other test class — whether it is a "dump" test, a `DyldCache*` /
+`Xcode*` snapshot, a `MachOSwiftSectionTests` unit test, or anything in
+`MachOSymbolsTests` / `TypeIndexingTests` / `SwiftInspectionTests` — is
+excluded from CI runs. Those tests remain fully functional locally.
+
+## Design
+
+### 1. Build the fixture
+
+Add a step before `swift test` that builds `SymbolTestsCore.framework` using
+`xcodebuild`, writing to the exact `DerivedData` path that
+`MachOFileName.SymbolTestsCore` (in
+`Sources/MachOTestingSupport/MachOFileName.swift`) expects:
+
+```yaml
+- name: Build SymbolTestsCore fixture
+  run: |
+    xcodebuild \
+      -project Tests/Projects/SymbolTests/SymbolTests.xcodeproj \
+      -scheme SymbolTestsCore \
+      -configuration Release \
+      -derivedDataPath Tests/Projects/SymbolTests/DerivedData \
+      -destination 'generic/platform=macOS' \
+      build
+```
+
+`MachOFileName.SymbolTestsCore.rawValue` is a path relative to
+`#filePath` inside `MachOTestingSupport`:
+
+```
+../../Tests/Projects/SymbolTests/DerivedData/SymbolTests/Build/Products/Release/SymbolTestsCore.framework/Versions/A/SymbolTestsCore
+```
+
+The `-derivedDataPath` value above resolves to the same `Release` product
+location. No test-code changes are required.
+
+### 2. Filter test runs
+
+Pass a single combined regex to `swift test --filter`:
+
+```
+\.(MachOFileDumpSnapshotTests|MachOFileInterfaceSnapshotTests|STCoreE2ETests|STCoreTests)(/|$)
+```
+
+- Leading `\.` anchors against the module prefix (`SwiftDumpTests.`,
+  `SwiftInterfaceTests.`) so the names can't match module-less substrings.
+- Trailing `(/|$)` uses a word-boundary-style anchor so `STCoreTests` does
+  **not** also match `STCoreE2ETests`.
+
+Both Debug and Release `swift test` invocations receive this filter.
+
+### 3. Environment upgrade
+
+Both workflows move to macOS 26.2 + Xcode 26.2.
+
+`.github/workflows/macOS.yml`:
+
+- `matrix.os`: `macos-15` → `macos-26`
+- `matrix.xcode-version`: `"16.3"` → `"26.2"`
+- `matrix.release`: `2024` → `2026`
+
+`.github/workflows/release.yml`:
+
+- `runs-on`: `macos-15` → `macos-26`
+- `Setup Xcode` with xcode-version `"16.3"` → `"26.2"`
+
+## Final workflow shape
+
+```yaml
+# .github/workflows/macOS.yml
+name: macOS
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  macos_test:
+    name: Execute tests on macOS
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-26]
+        xcode-version: ["26.2"]
+        release: [2026]
+    runs-on: ${{ matrix.os }}
+    env:
+      MACHO_SWIFT_SECTION_SILENT_TEST: 1
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.xcode-version }}
+      - name: Swift version
+        run: swift --version
+      - name: Build SymbolTestsCore fixture
+        run: |
+          xcodebuild \
+            -project Tests/Projects/SymbolTests/SymbolTests.xcodeproj \
+            -scheme SymbolTestsCore \
+            -configuration Release \
+            -derivedDataPath Tests/Projects/SymbolTests/DerivedData \
+            -destination 'generic/platform=macOS' \
+            build
+      - name: Build and run tests in debug mode
+        run: |
+          swift test \
+            -c debug \
+            --build-path .build-test-debug \
+            --filter '\.(MachOFileDumpSnapshotTests|MachOFileInterfaceSnapshotTests|STCoreE2ETests|STCoreTests)(/|$)'
+      - name: Build and run tests in release mode
+        run: |
+          swift test \
+            -c release \
+            --build-path .build-test-release \
+            --filter '\.(MachOFileDumpSnapshotTests|MachOFileInterfaceSnapshotTests|STCoreE2ETests|STCoreTests)(/|$)'
+```
+
+`release.yml` keeps its existing shape, with only the runner and Xcode
+version bumped.
+
+## Trade-offs
+
+- **Whitelist maintenance.** New test classes that belong in CI must be added
+  to the regex. The alternative (a blacklist of environment-dependent tests)
+  would drift the opposite way — new tests get included by accident. The
+  whitelist matches the intent ("CI only runs reproducible fixture-based
+  tests") more directly.
+- **`xcodebuild` adds wall-clock time.** Expected ~20-40 seconds for a single
+  Release build of the small fixture framework. Acceptable given it's a
+  one-time per-run cost and the alternative (checking in the binary) adds
+  other problems.
+- **Debug and Release both run.** Preserved from the existing workflow. If
+  compile time on `macos-26` becomes a concern later, dropping to Debug-only
+  is a one-line change.
+- **Regex vs. multiple `--filter` flags.** A single regex with an anchored
+  word boundary is more compact and avoids the `STCoreTests` ⊂ `STCoreE2ETests`
+  substring pitfall that four separate `--filter` flags would have.
+
+## Verification
+
+After the workflow change lands, a CI run on the next PR should:
+
+1. Successfully complete the `Build SymbolTestsCore fixture` step and leave a
+   framework at
+   `Tests/Projects/SymbolTests/DerivedData/SymbolTests/Build/Products/Release/SymbolTestsCore.framework`.
+2. Run exactly the four whitelisted test classes (visible in the test log),
+   one invocation per config (Debug + Release).
+3. Not attempt `DyldCache*`, `Xcode*`, `MachOImage*`, or `*DumpTests` (non-
+   Snapshot) classes.

--- a/docs/superpowers/specs/2026-04-18-ci-test-filter-design.md
+++ b/docs/superpowers/specs/2026-04-18-ci-test-filter-design.md
@@ -20,14 +20,14 @@ directory is listed in `.gitignore`. The current workflow does not build this
 artifact, so even the self-contained fixture tests can't run.
 
 Separately, the workflow pins `macos-15` + Xcode `16.3`. Project requirements
-have moved to macOS 26.2 + Xcode 26.2.
+have moved to macOS 26.2 + Xcode 26.4.
 
 ## Goals
 
 - CI runs only the test classes that work without a developer-machine
   environment.
 - CI builds the `SymbolTestsCore.framework` fixture before running tests.
-- CI and the release workflow both run on `macos-26` + Xcode `26.2`.
+- CI and the release workflow both run on `macos-26` + Xcode `26.4`.
 - No changes to test source files — the filter lives in CI configuration only.
 
 ## Non-Goals
@@ -95,17 +95,24 @@ Both Debug and Release `swift test` invocations receive this filter.
 
 ### 3. Environment upgrade
 
-Both workflows move to macOS 26.2 + Xcode 26.2.
+Both workflows move to macOS 26 (`macos-26` runner image) + Xcode 26.4.
 
 `.github/workflows/macOS.yml`:
 
 - `matrix.os`: `macos-15` → `macos-26`
-- `matrix.xcode-version`: `"16.3"` → `"26.2"`
+- `matrix.xcode-version`: `"16.3"` → `"26.4"`
 
 `.github/workflows/release.yml`:
 
 - `runs-on`: `macos-15` → `macos-26`
-- `Setup Xcode` with xcode-version `"16.3"` → `"26.2"`
+- `Setup Xcode` with xcode-version `"16.3"` → `"26.4"`
+
+**Note on Xcode version:** The original requirement was Xcode 26.2, but
+26.2 ships Swift 6.2.3, whose compiler emits a `.swiftinterface`
+containing `nonisolated(nonsending)` syntax (auto-enabled by the macOS
+26 SDK's default upcoming features) that the same compiler then refuses
+to verify. Xcode 26.4 / Swift 6.3 fixed this. The bump was the smallest
+change that lets the fixture build on CI.
 
 ## Final workflow shape
 
@@ -114,7 +121,7 @@ Cache DerivedData, Build SymbolTestsCore fixture, Upload logs on failure,
 Build and run tests). Only three lines change:
 
 - `matrix.os: macos-15` → `matrix.os: macos-26`
-- `matrix.xcode-version: "16.3"` → `matrix.xcode-version: "26.2"`
+- `matrix.xcode-version: "16.3"` → `matrix.xcode-version: "26.4"`
 - Both `swift test` invocations gain a single `--filter` argument:
   `'\.(SymbolTestsCoreDumpSnapshotTests|SymbolTestsCoreInterfaceSnapshotTests|SymbolTestsCoreCoverageInvariantTests|STCoreE2ETests|STCoreTests)(/|$)'`
 
@@ -122,7 +129,7 @@ Build and run tests). Only three lines change:
 version bumped:
 
 - `runs-on: macos-15` → `runs-on: macos-26`
-- `xcode-version: "16.3"` → `xcode-version: "26.2"`
+- `xcode-version: "16.3"` → `xcode-version: "26.4"`
 
 ## Trade-offs
 

--- a/docs/superpowers/specs/2026-04-18-ci-test-filter-design.md
+++ b/docs/superpowers/specs/2026-04-18-ci-test-filter-design.md
@@ -40,13 +40,17 @@ have moved to macOS 26.2 + Xcode 26.2.
 
 ## Scope: Tests that run in CI (whitelist)
 
-Exactly four test classes run in CI. All of them read from
-`SymbolTestsCore.framework`:
+Exactly five test classes run in CI. Four of them read from
+`SymbolTestsCore.framework`; the fifth (`SymbolTestsCoreCoverageInvariantTests`)
+is a pure-Swift invariant that walks the `SymbolTestsCore/*.swift` source
+files and confirms `SymbolTestsCoreDumpSnapshotTests` has a per-category
+`@Test` method for each of them:
 
 | Test class | File | Category |
 |---|---|---|
-| `MachOFileDumpSnapshotTests` | `Tests/SwiftDumpTests/Snapshots/MachOFileDumpSnapshotTests.swift` | Dump snapshot |
-| `MachOFileInterfaceSnapshotTests` | `Tests/SwiftInterfaceTests/Snapshots/MachOFileInterfaceSnapshotTests.swift` | Interface snapshot |
+| `SymbolTestsCoreDumpSnapshotTests` | `Tests/SwiftDumpTests/Snapshots/SymbolTestsCoreDumpSnapshotTests.swift` | Dump snapshot |
+| `SymbolTestsCoreInterfaceSnapshotTests` | `Tests/SwiftInterfaceTests/Snapshots/SymbolTestsCoreInterfaceSnapshotTests.swift` | Interface snapshot |
+| `SymbolTestsCoreCoverageInvariantTests` | `Tests/SwiftDumpTests/Snapshots/SymbolTestsCoreCoverageInvariantTests.swift` | Coverage invariant |
 | `STCoreE2ETests` | `Tests/SwiftInterfaceTests/SymbolTestsCoreE2ETests.swift` | Fixture E2E |
 | `STCoreTests` | `Tests/SwiftInterfaceTests/SymbolTestsCoreIntegrationTests.swift` | Fixture integration |
 
@@ -77,13 +81,15 @@ No change is needed for fixture construction.
 Pass a single combined regex to `swift test --filter`:
 
 ```
-\.(MachOFileDumpSnapshotTests|MachOFileInterfaceSnapshotTests|STCoreE2ETests|STCoreTests)(/|$)
+\.(SymbolTestsCoreDumpSnapshotTests|SymbolTestsCoreInterfaceSnapshotTests|SymbolTestsCoreCoverageInvariantTests|STCoreE2ETests|STCoreTests)(/|$)
 ```
 
 - Leading `\.` anchors against the module prefix (`SwiftDumpTests.`,
   `SwiftInterfaceTests.`) so the names can't match module-less substrings.
 - Trailing `(/|$)` uses a word-boundary-style anchor so `STCoreTests` does
-  **not** also match `STCoreE2ETests`.
+  **not** also match `STCoreE2ETests`, and `SymbolTestsCoreDumpSnapshotTests`
+  does not also accidentally match a hypothetical
+  `SymbolTestsCoreDumpSnapshotTestsExtra`.
 
 Both Debug and Release `swift test` invocations receive this filter.
 
@@ -110,7 +116,7 @@ Build and run tests). Only three lines change:
 - `matrix.os: macos-15` → `matrix.os: macos-26`
 - `matrix.xcode-version: "16.3"` → `matrix.xcode-version: "26.2"`
 - Both `swift test` invocations gain a single `--filter` argument:
-  `'\.(MachOFileDumpSnapshotTests|MachOFileInterfaceSnapshotTests|STCoreE2ETests|STCoreTests)(/|$)'`
+  `'\.(SymbolTestsCoreDumpSnapshotTests|SymbolTestsCoreInterfaceSnapshotTests|SymbolTestsCoreCoverageInvariantTests|STCoreE2ETests|STCoreTests)(/|$)'`
 
 `release.yml` keeps its existing shape, with only the runner and Xcode
 version bumped:
@@ -134,7 +140,7 @@ version bumped:
   is a one-line change.
 - **Regex vs. multiple `--filter` flags.** A single regex with an anchored
   word boundary is more compact and avoids the `STCoreTests` ⊂ `STCoreE2ETests`
-  substring pitfall that four separate `--filter` flags would have.
+  substring pitfall that separate `--filter` flags would have.
 
 ## Verification
 
@@ -143,7 +149,7 @@ After the workflow change lands, a CI run on the next PR should:
 1. Successfully complete the `Build SymbolTestsCore fixture` step and leave a
    framework at
    `Tests/Projects/SymbolTests/DerivedData/SymbolTests/Build/Products/Release/SymbolTestsCore.framework`.
-2. Run exactly the four whitelisted test classes (visible in the test log),
+2. Run exactly the five whitelisted test classes (visible in the test log),
    one invocation per config (Debug + Release).
 3. Not attempt `DyldCache*`, `Xcode*`, `MachOImage*`, or `*DumpTests` (non-
    Snapshot) classes.


### PR DESCRIPTION
## Summary
- Restrict `swift test` runs in `.github/workflows/macOS.yml` to the five
  `SymbolTestsCore`-based test classes (`SymbolTestsCoreDumpSnapshotTests`,
  `SymbolTestsCoreInterfaceSnapshotTests`,
  `SymbolTestsCoreCoverageInvariantTests`, `STCoreE2ETests`, `STCoreTests`).
  Other tests depend on developer-machine resources (Xcode frameworks,
  iOS Simulator runtimes, dyld shared cache) that don't exist on the CI
  runner.
- Bump both `macOS.yml` and `release.yml` to `macos-26` + Xcode `26.4`.
  (Originally targeted Xcode 26.2 but Swift 6.2.3 has a swiftinterface
  emit/verify bug that 26.4 / Swift 6.3 fixes — see spec note.)
- Five follow-up commits added during PR feedback to make the fixture
  build succeed on the CI runner: disable code signing on the fixture
  xcodebuild step, force ARM-only build, bump Xcode to 26.4, bump
  `swift-demangling` pin 0.1.0 → 0.1.1, symlink the fixture framework
  to the path tests expect.

## Test plan
- [x] CI run on this PR completes the `Build SymbolTestsCore fixture` step.
- [x] `Build and run tests in debug mode` and `Build and run tests in release mode` each report exactly the five whitelisted test classes (visible in the test log).
- [x] No `DyldCache*`, `Xcode*`, `MachOImage*`, or non-snapshot `*DumpTests` classes appear in the test log.

Spec: `docs/superpowers/specs/2026-04-18-ci-test-filter-design.md`
Plan: `docs/superpowers/plans/2026-04-18-ci-test-filter.md`