### PR TITLE
chore: migrate DyldPrivate dependency to swift-dyld-private

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -145,7 +145,7 @@ var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.9.4"),
     .package(url: "https://github.com/MxIris-DeveloperTool/swift-clang", from: "0.2.0"),
     .package(url: "https://github.com/MxIris-DeveloperTool/swift-apinotes", from: "0.1.0"),
-    .package(url: "https://github.com/MxIris-Reverse-Engineering/DyldPrivate", from: "1330.0.0"),
+    .package(url: "https://github.com/MxIris-Reverse-Engineering/swift-dyld-private", from: "1.1.0"),
     
     // CLI
     .package(url: "https://github.com/onevcat/Rainbow", from: "4.0.0"),
@@ -414,7 +414,7 @@ extension Target {
             .target(.MachOFoundation),
             .target(.MachOSwiftSectionC),
             .target(.Utilities),
-            .product(name: "DyldPrivate", package: "DyldPrivate"),
+            .product(name: "DyldPrivate", package: "swift-dyld-private"),
         ]
     )
 

--- a/Sources/MachOSwiftSection/Models/Metadata/MetadataProtocol.swift
+++ b/Sources/MachOSwiftSection/Models/Metadata/MetadataProtocol.swift
@@ -2,7 +2,6 @@ import Foundation
 import MachOKit
 import MachOExtensions
 import MachOReading
-import DyldPrivate
 
 public protocol MetadataProtocol<HeaderType>: ResolvableLocatableLayoutWrapper where Layout: MetadataLayout {
     associatedtype HeaderType: ResolvableLocatableLayoutWrapper = TypeMetadataHeader

--- a/Tests/MachOSwiftSectionTests/MetadataAccessorTests.swift
+++ b/Tests/MachOSwiftSectionTests/MetadataAccessorTests.swift
@@ -6,7 +6,6 @@ import MachOKit
 @testable import MachOTestingSupport
 @testable import MachOSwiftSection
 @testable import SwiftDump
-import DyldPrivate
 
 #if canImport(SwiftUI)
 import SwiftUI


### PR DESCRIPTION
## Summary
- Update package URL from `MxIris-Reverse-Engineering/DyldPrivate` to `MxIris-Reverse-Engineering/swift-dyld-private` (>= 1.1.0)
- Drop unused `import DyldPrivate` from `MetadataProtocol.swift` and `MetadataAccessorTests.swift`

## Test plan
- [x] `swift package update` resolves `swift-dyld-private` 1.1.0
- [x] `swift build` succeeds with 0 errors