### PR TITLE
fix(release): pin swift-semantic-string to exact 0.1.1

### DIFF
--- a/Changelogs/0.9.1.md
+++ b/Changelogs/0.9.1.md
@@ -1,0 +1,10 @@
+# 0.9.1
+
+## Fixes
+
+- **Release workflow**: pin `swift-semantic-string` to `exact: 0.1.1`. The previous `0.1.0` tag did not declare `platforms` in its `Package.swift`, which caused `swift build --arch x86_64` to fall back to the default macOS 10.13 deployment target and fail to compile Swift concurrency code in `Semantic/Components/Block.swift`. `0.1.1` declares `.macOS(.v10_15)`, restoring the universal binary build in the `Release` workflow. (We skip `0.1.2` because its `Joined` / `SemanticString` performance rewrites changed component traversal order in ways that break downstream snapshot tests.)
+
+## Requirements
+
+- Swift 6.2+
+- Xcode 26.0+ (CI validates on Xcode 26.4 / macOS 26)

--- a/Package.swift
+++ b/Package.swift
@@ -239,7 +239,7 @@ extension Package.Dependency {
         ),
         remote: .package(
             url: "https://github.com/MxIris-Reverse-Engineering/swift-semantic-string",
-            exact: "0.1.0"
+            exact: "0.1.1"
         )
     )
 }


### PR DESCRIPTION
## Summary

- Tag `0.1.0` of `swift-semantic-string` did not declare `platforms` in its `Package.swift`. When the `Release` workflow ran `swift build --arch x86_64`, SwiftPM fell back to the default macOS 10.13 deployment target and rejected Swift concurrency usage in `Sources/Semantic/Components/Block.swift`, causing the 0.9.0 release build to fail.
- Tag `0.1.1` declares `.macOS(.v10_15)`, so pinning `exact: "0.1.1"` restores the universal binary build.
- We intentionally skip `0.1.2` because its `Joined` / `SemanticString` perf rewrites change component traversal order in ways that break downstream snapshot tests.
- Adds `Changelogs/0.9.1.md` for the follow-up release.

## Test plan

- [x] `swift build -c release --arch x86_64 --product swift-section` succeeds locally
- [ ] CI `macOS` workflow green on this PR
- [ ] After merge, tag `0.9.1` and verify the `Release` workflow publishes a universal binary