### PR TITLE
docs(changelog): correct MachOKit version in 0.10.0 notes

### DIFF
--- a/Changelogs/0.10.0.md
+++ b/Changelogs/0.10.0.md
@@ -51,7 +51,7 @@ If you consume MachOSwiftSection via SwiftPM, the following package URLs have mo
 - `MxIris-DeveloperTool-Forks/swift-clang` → `MxIris-DeveloperTool/swift-clang` (>= 0.2.0)
 - `MxIris-DeveloperTool-Forks/swift-apinotes` → `MxIris-DeveloperTool/swift-apinotes`
 
-Underlying MachOKit was bumped to `0.47.100`.
+Underlying MachOKit was bumped to `0.49.100` (based on upstream `0.49.0`).
 
 ## Requirements
 


### PR DESCRIPTION
## Summary

Correct the MachOKit version line in `Changelogs/0.10.0.md`. The release actually resolves the fork at `0.49.100` (upstream `0.49.0`), not `0.47.100`.

## Test plan

- [x] Edit only — no build required