### PR TITLE
fix: dispatch ReadingContext generic context via TypeContextDescriptorProtocol

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -89,11 +89,11 @@ jobs:
           swift test \
             -c debug \
             --build-path .build-test-debug \
-            --filter '\.(SymbolTestsCoreDumpSnapshotTests|SymbolTestsCoreInterfaceSnapshotTests|SymbolTestsCoreCoverageInvariantTests|STCoreE2ETests|STCoreTests)(/|$)'
+            --filter '\.(SymbolTestsCoreDumpSnapshotTests|SymbolTestsCoreInterfaceSnapshotTests|SymbolTestsCoreCoverageInvariantTests|STCoreE2ETests|STCoreTests|GenericSpecializationTests|GenericSpecializerAPITests|MultiPayloadEnumTests|MetadataReaderDemanglingTests)(/|$)'
 
       - name: Build and run tests in release mode
         run: |
           swift test \
             -c release \
             --build-path .build-test-release \
-            --filter '\.(SymbolTestsCoreDumpSnapshotTests|SymbolTestsCoreInterfaceSnapshotTests|SymbolTestsCoreCoverageInvariantTests|STCoreE2ETests|STCoreTests)(/|$)'
+            --filter '\.(SymbolTestsCoreDumpSnapshotTests|SymbolTestsCoreInterfaceSnapshotTests|SymbolTestsCoreCoverageInvariantTests|STCoreE2ETests|STCoreTests|GenericSpecializationTests|GenericSpecializerAPITests|MultiPayloadEnumTests|MetadataReaderDemanglingTests)(/|$)'

--- a/Package.swift
+++ b/Package.swift
@@ -227,7 +227,7 @@ extension Package.Dependency {
         ),
         remote: .package(
             url: "https://github.com/MxIris-Reverse-Engineering/swift-demangling",
-            from: "0.2.0"
+            from: "0.3.0"
         )
     )
     

--- a/Sources/MachOSwiftSection/Models/ContextDescriptor/ContextDescriptorProtocol.swift
+++ b/Sources/MachOSwiftSection/Models/ContextDescriptor/ContextDescriptorProtocol.swift
@@ -13,7 +13,10 @@ public protocol ContextDescriptorProtocol: ResolvableLocatableLayoutWrapper wher
     func parent() throws -> SymbolOrElement<ContextDescriptorWrapper>?
     func moduleContextDesciptor() throws -> (any ModuleContextDescriptorProtocol)?
     func isCImportedContextDescriptor() throws -> Bool
-    
+
+    func genericContext<Context: ReadingContext>(in context: Context) throws -> GenericContext?
+    func parent<Context: ReadingContext>(in context: Context) throws -> SymbolOrElement<ContextDescriptorWrapper>?
+
     subscript<T>(dynamicMember keyPath: KeyPath<ContextDescriptorFlags, T>) -> T { get }
 }
 

--- a/Sources/MachOSwiftSection/Models/Type/TypeContextDescriptorProtocol.swift
+++ b/Sources/MachOSwiftSection/Models/Type/TypeContextDescriptorProtocol.swift
@@ -46,6 +46,20 @@ extension TypeContextDescriptorProtocol {
     }
 }
 
+// MARK: - ReadingContext Support
+
+extension TypeContextDescriptorProtocol {
+    public func genericContext<Context: ReadingContext>(in context: Context) throws -> GenericContext? {
+        guard layout.flags.isGeneric else { return nil }
+        return try typeGenericContext(in: context)?.asGenericContext()
+    }
+
+    public func typeGenericContext<Context: ReadingContext>(in context: Context) throws -> TypeGenericContext? {
+        guard layout.flags.isGeneric else { return nil }
+        return try .init(contextDescriptor: self, in: context)
+    }
+}
+
 extension TypeContextDescriptorProtocol {
     public var hasSingletonMetadataInitialization: Bool {
         return layout.flags.kindSpecificFlags?.typeFlags?.hasSingletonMetadataInitialization ?? false

--- a/Sources/MachOSwiftSection/Models/Type/TypeContextDescriptorWrapper.swift
+++ b/Sources/MachOSwiftSection/Models/Type/TypeContextDescriptorWrapper.swift
@@ -61,11 +61,25 @@ public enum TypeContextDescriptorWrapper {
     public func genericContext() throws -> GenericContext? {
         return try contextDescriptor.genericContext()
     }
-    
+
     public func typeGenericContext() throws -> TypeGenericContext? {
         return try typeContextDescriptor.typeGenericContext()
     }
-    
+
+    // MARK: - ReadingContext Support
+
+    public func parent<Context: ReadingContext>(in context: Context) throws -> SymbolOrElement<ContextDescriptorWrapper>? {
+        return try contextDescriptor.parent(in: context)
+    }
+
+    public func genericContext<Context: ReadingContext>(in context: Context) throws -> GenericContext? {
+        return try contextDescriptor.genericContext(in: context)
+    }
+
+    public func typeGenericContext<Context: ReadingContext>(in context: Context) throws -> TypeGenericContext? {
+        return try typeContextDescriptor.typeGenericContext(in: context)
+    }
+
     public var asContextDescriptorWrapper: ContextDescriptorWrapper {
         return .type(self)
     }
@@ -207,7 +221,17 @@ public enum ValueTypeDescriptorWrapper {
     public func genericContext() throws -> GenericContext? {
         return try contextDescriptor.genericContext()
     }
-    
+
+    // MARK: - ReadingContext Support
+
+    public func parent<Context: ReadingContext>(in context: Context) throws -> SymbolOrElement<ContextDescriptorWrapper>? {
+        return try contextDescriptor.parent(in: context)
+    }
+
+    public func genericContext<Context: ReadingContext>(in context: Context) throws -> GenericContext? {
+        return try contextDescriptor.genericContext(in: context)
+    }
+
     public var asTypeContextDescriptorWrapper: TypeContextDescriptorWrapper {
         switch self {
         case .enum(let enumDescriptor):

--- a/Sources/MachOTestingSupport/DumpableTests.swift
+++ b/Sources/MachOTestingSupport/DumpableTests.swift
@@ -109,7 +109,7 @@ extension DumpableTests {
             let opaqueTypeDescriptor = try machO.readWrapperElement(offset: symbol.offset) as OpaqueTypeDescriptor
             let opaqueType = try OpaqueType(descriptor: opaqueTypeDescriptor, in: machO)
             for underlyingTypeArgumentMangledName in opaqueType.underlyingTypeArgumentMangledNames {
-                try MetadataReader.demangleType(for: underlyingTypeArgumentMangledName, in: machO).print(using: .interface).print()
+                try await MetadataReader.demangleType(for: underlyingTypeArgumentMangledName, in: machO).print(using: .interface).print()
             }
             "-----".print()
         }

--- a/Sources/SwiftDump/Dumper/ClassDumper.swift
+++ b/Sources/SwiftDump/Dumper/ClassDumper.swift
@@ -466,7 +466,7 @@ package struct ClassDumper<MachO: MachOSwiftSectionRepresentableWithCache>: Type
     package func validNode(for symbols: Symbols, visitedNodes: borrowing OrderedSet<Node> = []) async throws -> Node? {
         let currentInterfaceName = try await _name(using: .options(.interfaceType)).string
         for symbol in symbols {
-            if let node = try? MetadataReader.demangleSymbol(for: symbol, in: machO), let classNode = node.first(of: .class), classNode.print(using: .interfaceType) == currentInterfaceName, !visitedNodes.contains(node) {
+            if let node = try? MetadataReader.demangleSymbol(for: symbol, in: machO), let classNode = node.first(of: .class), await classNode.print(using: .interfaceType) == currentInterfaceName, !visitedNodes.contains(node) {
                 return node
             }
         }

--- a/Sources/SwiftDump/Dumper/ProtocolConformanceDumper.swift
+++ b/Sources/SwiftDump/Dumper/ProtocolConformanceDumper.swift
@@ -161,7 +161,7 @@ package struct ProtocolConformanceDumper<MachO: MachOSwiftSectionRepresentableWi
         guard let symbols = try await Symbols.resolve(from: requirement.offset, in: machO) else { return nil }
         for symbol in symbols {
             if let node = try? MetadataReader.demangleSymbol(for: symbol, in: machO) {
-                return node.print(using: typeNameOptions)
+                return await node.print(using: typeNameOptions)
             }
         }
         return nil
@@ -169,7 +169,7 @@ package struct ProtocolConformanceDumper<MachO: MachOSwiftSectionRepresentableWi
 
     private func _node(for symbols: Symbols, typeName: String, visitedNodes: borrowing OrderedSet<Node> = []) async throws -> Node? {
         for symbol in symbols {
-            if let node = try? MetadataReader.demangleSymbol(for: symbol, in: machO), let dumpedNode = node.preorder().first(where: { $0.kind == .protocolConformance }), let symbolTypeName = dumpedNode.children.at(0)?.print(using: .interfaceType), symbolTypeName == typeName || PrimitiveTypeMappingCache.shared.storage(in: machO)?.primitiveType(for: typeName) == symbolTypeName, !visitedNodes.contains(node) {
+            if let node = try? MetadataReader.demangleSymbol(for: symbol, in: machO), let dumpedNode = node.preorder().first(where: { $0.kind == .protocolConformance }), let symbolTypeName = await dumpedNode.children.at(0)?.print(using: .interfaceType), symbolTypeName == typeName || PrimitiveTypeMappingCache.shared.storage(in: machO)?.primitiveType(for: typeName) == symbolTypeName, !visitedNodes.contains(node) {
                 return node
             }
         }

--- a/Sources/SwiftDump/Dumper/ProtocolDumper.swift
+++ b/Sources/SwiftDump/Dumper/ProtocolDumper.swift
@@ -147,7 +147,7 @@ package struct ProtocolDumper<MachO: MachOSwiftSectionRepresentableWithCache>: N
     private func validNode(for symbols: Symbols, visitedNode: borrowing OrderedSet<Node> = []) async throws -> Node? {
         let currentInterfaceName = try await _name(using: .options(.interfaceType)).string
         for symbol in symbols {
-            if let node = try? MetadataReader.demangleSymbol(for: symbol, in: machO), let protocolNode = node.first(of: .protocol), protocolNode.print(using: .interfaceType) == currentInterfaceName, !visitedNode.contains(node) {
+            if let node = try? MetadataReader.demangleSymbol(for: symbol, in: machO), let protocolNode = node.first(of: .protocol), await protocolNode.print(using: .interfaceType) == currentInterfaceName, !visitedNode.contains(node) {
                 return node
             }
         }

--- a/Sources/SwiftInterface/SwiftInterfaceBuilderOpaqueTypeProvider.swift
+++ b/Sources/SwiftInterface/SwiftInterfaceBuilderOpaqueTypeProvider.swift
@@ -62,13 +62,13 @@ public struct SwiftInterfaceBuilderOpaqueTypeProvider<MachO: MachOSwiftSectionRe
                 if let associatedTypes = associatedTypeByParamType[param] {
                     for associatedType in associatedTypes {
                         let primaryAssociatedTypeNode = substitutionMap.rootOriginal(for: associatedType)
-                        primaryAssociatedTypes.append(primaryAssociatedTypeNode.print(using: .opaqueTypeBuilderOnly))
+                        await primaryAssociatedTypes.append(primaryAssociatedTypeNode.print(using: .opaqueTypeBuilderOnly))
                     }
                 }
 
                 if let witnessTypes = witnessTypeByParamType[param] {
                     for witnessType in witnessTypes {
-                        primaryAssociatedTypes.append(witnessType.print(using: .opaqueTypeBuilderOnly))
+                        await primaryAssociatedTypes.append(witnessType.print(using: .opaqueTypeBuilderOnly))
                     }
                 }
 

--- a/Sources/SwiftInterface/SwiftInterfaceIndexer.swift
+++ b/Sources/SwiftInterface/SwiftInterfaceIndexer.swift
@@ -578,7 +578,7 @@ public final class SwiftInterfaceIndexer<MachO: MachOSwiftSectionRepresentableWi
         var failedExtensions = 0
 
         for (node, memberSymbols) in memberSymbolsByName {
-            let name = node.print(using: .interfaceTypeBuilderOnly)
+            let name = await node.print(using: .interfaceTypeBuilderOnly)
             guard let typeInfo = symbolIndexStore.typeInfo(for: name, in: machO) else {
                 eventDispatcher.dispatch(.extensionTargetNotFound(targetName: name))
                 continue

--- a/Tests/MachOSwiftSectionTests/OpaqueTypeTests.swift
+++ b/Tests/MachOSwiftSectionTests/OpaqueTypeTests.swift
@@ -16,7 +16,7 @@ extension OpaqueTypeTests {
             guard symbol.offset > 0 else { continue }
             print("Offset:", symbol.offset)
             print("Demangled:")
-            symbol.demangledNode.print(using: .default).print()
+            await symbol.demangledNode.print(using: .default).print()
             symbol.demangledNode.description.print()
             let opaqueTypeDescriptor = try OpaqueTypeDescriptor.resolve(from: symbol.offset, in: machO)
             let opaqueType = try OpaqueType(descriptor: opaqueTypeDescriptor, in: machO)
@@ -32,7 +32,7 @@ extension OpaqueTypeTests {
             for underlyingTypeArgumentMangledName in opaqueType.underlyingTypeArgumentMangledNames {
                 let node = try MetadataReader.demangleType(for: underlyingTypeArgumentMangledName, in: machO)
                 node.description.print()
-                node.print(using: .default).print()
+                await node.print(using: .default).print()
             }
             print("--------------------")
         }

--- a/Tests/MachOSwiftSectionTests/SymbolIndexStoreTests.swift
+++ b/Tests/MachOSwiftSectionTests/SymbolIndexStoreTests.swift
@@ -42,7 +42,7 @@ final class SymbolIndexStoreTests: DyldCacheTests, @unchecked Sendable {
     @Test func globalSymbols() async throws {
         let symbols = symbolIndexStore.globalSymbols(of: .function, in: machOFileInCache)
         for symbol in symbols {
-            symbol.demangledNode.print(using: .default).print()
+            await symbol.demangledNode.print(using: .default).print()
             symbol.demangledNode.description.print()
             print("----------------------------")
         }
@@ -66,7 +66,7 @@ final class SymbolIndexStoreTests: DyldCacheTests, @unchecked Sendable {
                 for (node, _) in memberSymbolsByNode {
                     print("Node: ")
                     print(node)
-                    print(node.print())
+                    await print(node.print())
                 }
             }
             print("---------------------")

--- a/Tests/MachOSymbolsTests/DemanglingTests.swift
+++ b/Tests/MachOSymbolsTests/DemanglingTests.swift
@@ -36,7 +36,7 @@ extension DemanglingTests {
             let stdlibTree = MachOTestingSupport.stdlib_demangleNodeTree(mangledName)
 
             do {
-                let node = try demangleAsNode(mangledName)
+                let node = try await demangleAsNode(mangledName)
                 var allPassed = true
 
                 // 1. Node tree check
@@ -57,7 +57,7 @@ extension DemanglingTests {
                 }
 
                 // 2. Remangle check
-                let remangled = try Demangling.mangleAsString(node)
+                let remangled = try await Demangling.mangleAsString(node)
                 if remangled != mangledName {
                     // Known issue: Md vs MD (Apple-internal lowercase 'd')
                     if mangledName.hasSuffix("Md"), remangled.hasSuffix("MD"),

--- a/Tests/MachOSymbolsTests/DyldCacheSymbolDemanglingTests.swift
+++ b/Tests/MachOSymbolsTests/DyldCacheSymbolDemanglingTests.swift
@@ -13,7 +13,7 @@ final class DyldCacheSymbolDemanglingTests: DyldCacheSymbolTests, DemanglingTest
     }
 
     @Test func demangle() async throws {
-        let node = try Demangling.demangleAsNode("_$sSis15WritableKeyPathCy17RealityFoundation23PhysicallyBasedMaterialVAE9BaseColorVGTHTm")
+        let node = try await Demangling.demangleAsNode("_$sSis15WritableKeyPathCy17RealityFoundation23PhysicallyBasedMaterialVAE9BaseColorVGTHTm")
 //        try Demangling.mangleAsString(node).print()
         node.description.print()
     }
@@ -22,7 +22,7 @@ final class DyldCacheSymbolDemanglingTests: DyldCacheSymbolTests, DemanglingTest
         let mangledName = "_$s7SwiftUI11DisplayListV10PropertiesVs9OptionSetAAsAFP8rawValuex03RawI0Qz_tcfCTW"
         let demangleNodeTree = MachOTestingSupport.stdlib_demangleNodeTree(mangledName)
         let stdlibNodeDescription = try #require(demangleNodeTree)
-        let swiftSectionNodeDescription = try demangleAsNode(mangledName).description + "\n"
+        let swiftSectionNodeDescription = try await demangleAsNode(mangledName).description + "\n"
         #expect(stdlibNodeDescription == swiftSectionNodeDescription)
     }
 }

--- a/Tests/MachOSymbolsTests/DyldCacheSymbolSimpleTests.swift
+++ b/Tests/MachOSymbolsTests/DyldCacheSymbolSimpleTests.swift
@@ -16,13 +16,13 @@ final class DyldCacheSymbolSimpleTests: DyldCacheSymbolTests, @unchecked Sendabl
         let imageName: MachOImageName = .SwiftUICore
         let symbols = try await symbols(for: imageName)
         for symbol in symbols {
-            let node = try demangleAsNode(symbol.stringValue)
+            let node = try await demangleAsNode(symbol.stringValue)
             guard !symbol.stringValue.hasSuffix("$delayInitStub") else { continue }
             string += "---------------------------------------"
             string += "\n"
             string += symbol.stringValue
             string += "\n"
-            string += node.print(using: .default)
+            await string += node.print(using: .default)
             string += "\n"
             string += node.description
             string += "\n"
@@ -38,7 +38,7 @@ final class DyldCacheSymbolSimpleTests: DyldCacheSymbolTests, @unchecked Sendabl
     }
 
     @Test func demangle() async throws {
-        try demangleAsNode("_TtCs12_SwiftObject").print().print()
+        try await demangleAsNode("_TtCs12_SwiftObject").print().print()
     }
 }
 

--- a/Tests/MachOSymbolsTests/ExternalSymbolTests.swift
+++ b/Tests/MachOSymbolsTests/ExternalSymbolTests.swift
@@ -9,7 +9,7 @@ final class ExternalSymbolTests: MachOFileTests, @unchecked Sendable {
     @Test func machOSections() async throws {
         for symbol in machOFile.symbols where symbol.nlist.isExternal && symbol.name.isSwiftSymbol {
             let demangledNode = try symbol.demangledNode
-            demangledNode.print(using: .default).print()
+            await demangledNode.print(using: .default).print()
             demangledNode.description.print()
             "-----------------------------".print()
         }

--- a/Tests/SwiftInspectionTests/MetadataReaderTests.swift
+++ b/Tests/SwiftInspectionTests/MetadataReaderTests.swift
@@ -65,7 +65,7 @@ final class MetadataReaderImageTests: MachOImageTests, @unchecked Sendable {
 
     @Test func demangleTypeFromMachO() async throws {
         // Test that demangling works with in-process metadata
-        let node = try demangleAsNode("$sSi")
+        let node = try await demangleAsNode("$sSi")
 
         #expect(node.kind == .global)
         #expect(node.first(of: .structure) != nil)
@@ -85,7 +85,7 @@ final class MetadataReaderFileTests: MachOFileTests, @unchecked Sendable {
     override class var fileName: MachOFileName { .iOS_26_2_Simulator_SwiftUI }
 
     @Test func demangleTypeFromFile() async throws {
-        let node = try demangleAsNode("$sSi")
+        let node = try await demangleAsNode("$sSi")
         #expect(node.kind == .global)
     }
 

--- a/Tests/SwiftInspectionTests/MultiPayloadEnumTests.swift
+++ b/Tests/SwiftInspectionTests/MultiPayloadEnumTests.swift
@@ -27,7 +27,7 @@ final class MultiPayloadEnumTests: MachOImageTests {
         let descriptors = try machO.swift.multiPayloadEnumDescriptors
         for descriptor in descriptors {
             let inProcessDescriptor = descriptor.asPointerWrapper(in: machO)
-            try multiPayloadEnumDescriptorByMangledName[MetadataReader.demangleType(for: inProcessDescriptor.mangledTypeName()).print(using: demangleOptions)] = inProcessDescriptor
+            try await multiPayloadEnumDescriptorByMangledName[MetadataReader.demangleType(for: inProcessDescriptor.mangledTypeName()).print(using: demangleOptions)] = inProcessDescriptor
         }
     }
 
@@ -54,7 +54,7 @@ final class MultiPayloadEnumTests: MachOImageTests {
             let records = try fieldDescriptor.records()
             guard !records.isEmpty else { continue }
 
-            let typeName = try MetadataReader.demangleContext(for: .type(.enum(typeContextDescriptor as! EnumDescriptor))).print(using: demangleOptions)
+            let typeName = try await MetadataReader.demangleContext(for: .type(.enum(typeContextDescriptor as! EnumDescriptor))).print(using: demangleOptions)
 
             print(typeName)
             print("")
@@ -117,10 +117,10 @@ final class MultiPayloadEnumTests: MachOImageTests {
                     }
                 }
 
-                let mangledTypeNameString = try mangleAsString(node)
+                let mangledTypeNameString = try await mangleAsString(node)
                 if let metatype = try RuntimeFunctions.getTypeByMangledNameInContext(mangledTypeName, genericContext: nil, genericArguments: nil) {
                     let currentMetadata = try Metadata.createInProcess(metatype)
-                    try print("\(indirectCaseString)case \(record.fieldName())\(payloadString("\(node.print(using: .interfaceTypeBuilderOnly))"))")
+                    try print("\(indirectCaseString)case \(record.fieldName())\(payloadString("\(await node.print(using: .interfaceTypeBuilderOnly))"))")
                     let metadataWrapper = try currentMetadata.asMetadataWrapper()
                     let typeLayout = try currentMetadata.asFullMetadata().valueWitnesses.resolve().typeLayout
                     let indentLevel = 1
@@ -130,7 +130,7 @@ final class MultiPayloadEnumTests: MachOImageTests {
                             let tupleElementMetadata = try element.type.resolve()
                             if let descriptor = try tupleElementMetadata.typeContextDescriptorWrapper()?.asContextDescriptorWrapper {
                                 print(indent + "Index: " + index.description)
-                                try print(indent + "Type: " + MetadataReader.demangleContext(for: descriptor).print(using: demangleOptions))
+                                try await print(indent + "Type: " + MetadataReader.demangleContext(for: descriptor).print(using: demangleOptions))
                             }
                             let tupleElementTypeLayout = try tupleElementMetadata.asFullMetadata().valueWitnesses.resolve().typeLayout
                             print(indent + "- " + tupleElementTypeLayout.description)
@@ -146,7 +146,7 @@ final class MultiPayloadEnumTests: MachOImageTests {
                     optionalSize = optionalTypeLayout.size.cast()
 
                 } else {
-                    try print("NotFound:", "case", record.fieldName(), mangledTypeNameString, node.print(using: .default))
+                    try await print("NotFound:", "case", record.fieldName(), mangledTypeNameString, node.print(using: .default))
                 }
             }
             print("")

--- a/Tests/SwiftInterfaceTests/NodePrinterTests.swift
+++ b/Tests/SwiftInterfaceTests/NodePrinterTests.swift
@@ -22,7 +22,7 @@ struct NodePrinterUnitTests {
         ("$s4Main3barSiyF", "func bar() -> Int"),
     ])
     func functionNodePrinterBasic(mangled: String, expectedContains: String) async throws {
-        let node = try demangleAsNode(mangled)
+        let node = try await demangleAsNode(mangled)
         var printer = FunctionNodePrinter(isOverride: false)
         let result = try await printer.printRoot(node).string
 
@@ -30,7 +30,7 @@ struct NodePrinterUnitTests {
     }
 
     @Test func functionNodePrinterWithOverride() async throws {
-        let node = try demangleAsNode("$s4Main3fooyySiF")
+        let node = try await demangleAsNode("$s4Main3fooyySiF")
         var printer = FunctionNodePrinter(isOverride: true)
         let result = try await printer.printRoot(node).string
 
@@ -40,7 +40,7 @@ struct NodePrinterUnitTests {
     // MARK: - VariableNodePrinter
 
     @Test func variableNodePrinterStored() async throws {
-        let node = try demangleAsNode("$s4Main3fooSivp")  // Main.foo: Int
+        let node = try await demangleAsNode("$s4Main3fooSivp")  // Main.foo: Int
         var printer = VariableNodePrinter(isStored: true, isOverride: false, hasSetter: true, indentation: 0)
         let result = try await printer.printRoot(node).string
 
@@ -48,7 +48,7 @@ struct NodePrinterUnitTests {
     }
 
     @Test func variableNodePrinterComputed() async throws {
-        let node = try demangleAsNode("$s4Main3fooSivg")  // Main.foo.getter
+        let node = try await demangleAsNode("$s4Main3fooSivg")  // Main.foo.getter
         var printer = VariableNodePrinter(isStored: false, isOverride: false, hasSetter: false, indentation: 0)
         let result = try await printer.printRoot(node).string
 
@@ -56,7 +56,7 @@ struct NodePrinterUnitTests {
     }
 
     @Test func variableNodePrinterWithOverride() async throws {
-        let node = try demangleAsNode("$s4Main3fooSivp")
+        let node = try await demangleAsNode("$s4Main3fooSivp")
         var printer = VariableNodePrinter(isStored: true, isOverride: true, hasSetter: true, indentation: 0)
         let result = try await printer.printRoot(node).string
 
@@ -74,7 +74,7 @@ struct NodePrinterUnitTests {
         ("$sSd", "Swift.Double"),
     ])
     func typeNodePrinterBasicTypes(mangled: String, expected: String) async throws {
-        let node = try demangleAsNode(mangled)
+        let node = try await demangleAsNode(mangled)
         var printer = TypeNodePrinter()
 
         // For type aliases like $sSi, the structure is Global > Structure
@@ -88,7 +88,7 @@ struct NodePrinterUnitTests {
     }
 
     @Test func typeNodePrinterOptional() async throws {
-        let node = try demangleAsNode("$sSiSg")  // Int?
+        let node = try await demangleAsNode("$sSiSg")  // Int?
         var printer = TypeNodePrinter()
 
         guard let typeNode = node.children.first else {
@@ -102,7 +102,7 @@ struct NodePrinterUnitTests {
     }
 
     @Test func typeNodePrinterArray() async throws {
-        let node = try demangleAsNode("$sSaySiG")  // [Int]
+        let node = try await demangleAsNode("$sSaySiG")  // [Int]
         var printer = TypeNodePrinter()
 
         guard let typeNode = node.children.first else {
@@ -116,7 +116,7 @@ struct NodePrinterUnitTests {
     }
 
     @Test func typeNodePrinterDictionary() async throws {
-        let node = try demangleAsNode("$sSDySSSiG")  // [String: Int]
+        let node = try await demangleAsNode("$sSDySSSiG")  // [String: Int]
         var printer = TypeNodePrinter()
 
         guard let typeNode = node.children.first else {
@@ -132,7 +132,7 @@ struct NodePrinterUnitTests {
 
     @Test func typeNodePrinterGenericArray() async throws {
         // Test with a type that should produce non-empty output
-        let node = try demangleAsNode("$sSaySiGD")  // [Int] destructor
+        let node = try await demangleAsNode("$sSaySiGD")  // [Int] destructor
 
         // This demangled symbol has different structure, just verify no crash
         #expect(node.kind == .global)
@@ -140,7 +140,7 @@ struct NodePrinterUnitTests {
 
     @Test func typeNodePrinterModuleQualified() async throws {
         // Test custom type
-        let node = try demangleAsNode("$s4Main3FooV")
+        let node = try await demangleAsNode("$s4Main3FooV")
         var printer = TypeNodePrinter()
 
         guard let typeNode = node.children.first else {
@@ -156,7 +156,7 @@ struct NodePrinterUnitTests {
 
     @Test func subscriptNodePrinterBasic() async throws {
         // subscript with getter only
-        let node = try demangleAsNode("$s4Main3FooVyS2icig")  // Main.Foo.subscript(_:) getter
+        let node = try await demangleAsNode("$s4Main3FooVyS2icig")  // Main.Foo.subscript(_:) getter
         var printer = SubscriptNodePrinter(isOverride: false, hasSetter: false, indentation: 1)
         let result = try await printer.printRoot(node).string
 
@@ -166,7 +166,7 @@ struct NodePrinterUnitTests {
     }
 
     @Test func subscriptNodePrinterWithSetter() async throws {
-        let node = try demangleAsNode("$s4Main3FooVyS2icig")
+        let node = try await demangleAsNode("$s4Main3FooVyS2icig")
         var printer = SubscriptNodePrinter(isOverride: false, hasSetter: true, indentation: 1)
         let result = try await printer.printRoot(node).string
 
@@ -186,7 +186,7 @@ final class NodePrinterIntegrationTests: DyldCacheTests, @unchecked Sendable {
     override class var cacheImageName: MachOImageName { .SwiftUICore }
 
     @Test func functionNodeFromSymbol() async throws {
-        let node = try demangleAsNode("_$s7SwiftUI19AnyStyleContextTypeV07acceptsC0ySbxmxQpRvzAA0dE0RzlF")
+        let node = try await demangleAsNode("_$s7SwiftUI19AnyStyleContextTypeV07acceptsC0ySbxmxQpRvzAA0dE0RzlF")
         var printer = FunctionNodePrinter(isOverride: false)
         let result = try await printer.printRoot(node).string
 
@@ -196,7 +196,7 @@ final class NodePrinterIntegrationTests: DyldCacheTests, @unchecked Sendable {
     }
 
     @Test func variableNodeFromSymbol() async throws {
-        let variableNode = try demangleAsNode("_$s7SwiftUI38HostingViewTransparentBackgroundReasonVs10SetAlgebraAAsADP7isEmptySbvgTW")
+        let variableNode = try await demangleAsNode("_$s7SwiftUI38HostingViewTransparentBackgroundReasonVs10SetAlgebraAAsADP7isEmptySbvgTW")
         var variableNodePrinter = VariableNodePrinter(isStored: false, isOverride: false, hasSetter: true, indentation: 0)
 
         guard let firstChild = variableNode.children.first else {


### PR DESCRIPTION
## Summary

- Fix `EXC_BAD_ACCESS` when any code path reads a `Struct`/`Class`/`Enum` descriptor's generic context through a `ReadingContext` (e.g. `InProcessContext`, `MachOContext`). Manifested as `readWrapperElements` attempting to walk ~`UInt32.max` `GenericValueDescriptor` slots in `GenericContext.swift:363`.
- Re-enable the previously crashing `MultiPayloadEnumTests` (signal 11 noted in 511b151) and the new `GenericSpecializationTests` by adding them to CI so regressions in this dispatch path are caught rather than crashing locally.

## Root Cause

`ContextDescriptorProtocol.genericContext<Context: ReadingContext>(in:)` was added in 511b151 as a protocol *extension* method only — it was never declared as a protocol requirement, and no override was provided on `TypeContextDescriptorProtocol`. When called through `any ContextDescriptorProtocol` (for example from `GenericContext.init.validParentGenericContextDescriptor?.genericContext(in: context)`), Swift statically dispatched to the base extension.

The base implementation builds `TargetGenericContext<GenericContextDescriptorHeader>` (8-byte header), but a type descriptor's generic context actually starts with `TypeGenericContextDescriptorHeader` (16 bytes — `instantiationCache` + `defaultInstantiationPattern` + `base`). The first 8 bytes were therefore read as `numParams`/`numRequirements`/`numKeyArguments`/`flags`, which frequently yielded a garbage `flags` with `.hasValues` set. That branch then read a fake `GenericValueHeader` and tried to load ~4 billion `GenericValueDescriptor` entries → crash.

Equivalent `MachOSwiftSectionRepresentableWithCache` and no-context paths already had the correct override on `TypeContextDescriptorProtocol` (dispatching via `typeGenericContext(in:)?.asGenericContext()`); only the `ReadingContext` variant was missing.

## Changes

- **ContextDescriptorProtocol**: promote `genericContext<Context: ReadingContext>(in:)` and `parent<Context: ReadingContext>(in:)` to protocol requirements so they participate in witness-table dispatch.
- **TypeContextDescriptorProtocol**: add `genericContext<Context: ReadingContext>(in:)` override routing through `typeGenericContext(in:)?.asGenericContext()`, plus a new `typeGenericContext<Context: ReadingContext>(in:)` — mirrors the existing `MachOSwiftSectionRepresentableWithCache` and in-process overloads.
- **TypeContextDescriptorWrapper / ValueTypeDescriptorWrapper**: add the matching `ReadingContext` overloads for `parent`/`genericContext`/`typeGenericContext` to keep the wrapper API symmetric.
- **CI (`.github/workflows/macOS.yml`)**: extend the debug & release test filters to include `GenericSpecializationTests`, `GenericSpecializerAPITests`, `MultiPayloadEnumTests`, and `MetadataReaderDemanglingTests`.

## Test Plan

- [x] `swift build` clean (0 errors, 2 pre-existing warnings unrelated to this change)
- [x] `swift test --filter GenericSpecializationTests` — 5/5 pass (previously crashed in `SwiftInterfaceIndexer.indexTypes` → `TargetGenericContext.initializeWithContext`)
- [x] `swift test --filter MultiPayloadEnumTests` — 1/1 pass (previously signal 11, noted in 511b151)
- [x] `swift test --filter MetadataReaderTests` — pass
- [ ] Full CI run (debug + release) on macos-26 / Xcode 26.4