### PR TITLE
release: 0.10.1

### DIFF
--- a/Changelogs/0.10.1.md
+++ b/Changelogs/0.10.1.md
@@ -1,0 +1,40 @@
+# 0.10.1
+
+## Highlights
+
+Patch release on top of `0.10.0`. Ships a critical generic-context dispatch fix that was crashing `StructDescriptor` / `ClassDescriptor` / `EnumDescriptor` reads made through `any ContextDescriptorProtocol`, and aligns demangling call sites with the new async API in `swift-demangling` 0.3.0.
+
+## Bug Fixes
+
+- **Generic context dispatch (signal-11 crash)**: the `ReadingContext` overload of `genericContext(in:)` introduced during the reading-context refactor was declared as a protocol extension only, with no override on `TypeContextDescriptorProtocol`. Calls through `any ContextDescriptorProtocol` therefore statically dispatched to the base implementation, which built a `TargetGenericContext<GenericContextDescriptorHeader>` (8-byte header) even when the descriptor was a `StructDescriptor` / `ClassDescriptor` / `EnumDescriptor`. Those descriptors actually start with `TypeGenericContextDescriptorHeader` (16 bytes — two relative offsets preceding the `base` header), so the read was misaligned by 8 bytes. The misaligned bytes usually surfaced as a garbage `valueHeader.numValues` of ~`UInt32.max`, after which `readWrapperElements` walked ~4 billion fabricated `GenericValueDescriptor` slots and crashed with `EXC_BAD_ACCESS`.
+  - Promoted `genericContext(in:)` and `parent(in:)` to protocol requirements on `ContextDescriptorProtocol` so they participate in witness-table dispatch.
+  - Added matching overrides on `TypeContextDescriptorProtocol` that route through `typeGenericContext(in:)?.asGenericContext()`, mirroring the `MachOSwiftSectionRepresentableWithCache` path.
+  - Mirrored the new overloads on `TypeContextDescriptorWrapper` / `ValueTypeDescriptorWrapper` for API parity.
+  - Resolves `EXC_BAD_ACCESS` in `MultiPayloadEnumTests` and in `GenericSpecializationTests.main` via `SwiftInterfaceIndexer.indexTypes`.
+
+## Dependencies
+
+- **`swift-demangling` minimum bumped to `0.3.0`**. 0.3.0 makes `Node.print`, `demangleAsNode`, and `mangleAsString` async (with stack-safe execution) and adds the `DemanglingTestingSupport` module. Call sites in `SwiftDump`, `SwiftInterface`, and the test suites have been migrated to `await` the new entry points. Downstream consumers using these public demangling APIs will need to `await` them as well.
+
+## CI
+
+- Added `GenericSpecializationTests`, `GenericSpecializerAPITests`, `MultiPayloadEnumTests`, and `MetadataReaderDemanglingTests` to the macOS matrix filter, so any future regression in the generic-context dispatch path surfaces in CI rather than as a local signal-11.
+- `Sources/swift-section/Version.swift` is now the single source of truth for the CLI version:
+  - `release.yml` no longer injects the version via heredoc; it fails a tagged release when `BundledVersion.value != github.ref_name`.
+  - A new `version-check.yml` workflow runs on every push to `main` and every PR, and fails when `Changelogs/<BundledVersion.value>.md` does not exist.
+  - The extraction shell is whitespace-tolerant and guards `grep`'s exit status so formatter changes cannot silently break the check.
+  - As a result, source builds (including Homebrew's source path) report the correct version without depending on CI injection.
+
+## Docs
+
+- Corrected MachOKit version in the `0.10.0` notes: `0.49.100` (based on upstream `0.49.0`), not `0.47.100`.
+- `KNOWN_ISSUES.md` annotated recent CI runs that reproduced the `SymbolIndexStore.demangledNode` data race so its flaky, parallel-harness-only nature is easier to recognize during triage.
+
+## Requirements
+
+- Swift 6.2+
+- Xcode 26.0+ (CI validates on Xcode 26.4 / macOS 26)
+
+## Known Issues
+
+See [KNOWN_ISSUES.md](https://github.com/MxIris-Reverse-Engineering/MachOSwiftSection/blob/0.10.1/KNOWN_ISSUES.md) — same two non-blocking parallel-harness concurrency items as 0.10.0.

--- a/Sources/swift-section/Version.swift
+++ b/Sources/swift-section/Version.swift
@@ -2,5 +2,5 @@
 // When bumping: also add Changelogs/<value>.md, then tag the release with the same string.
 // Verified by .github/workflows/version-check.yml (PR) and .github/workflows/release.yml (tag).
 enum BundledVersion {
-    static let value = "0.10.0"
+    static let value = "0.10.1"
 }


### PR DESCRIPTION
## Summary
- Patch release with a critical generic-context dispatch crash fix (resolves `EXC_BAD_ACCESS` in `MultiPayloadEnumTests` / `GenericSpecializationTests` via `SwiftInterfaceIndexer.indexTypes`).
- Bumps `swift-demangling` minimum to `0.3.0` and adopts the new async `demangleAsNode` / `Node.print` / `mangleAsString` APIs across dumpers, the interface builder, and test suites.
- Promotes `BundledVersion.value` in `Sources/swift-section/Version.swift` to the single source of truth for the CLI version, enforced by `version-check.yml` (matching `Changelogs/<value>.md`) and `release.yml` (matching tag).

## Test plan
- [ ] `Version Check` workflow is green (confirms `Changelogs/0.10.1.md` exists and matches `BundledVersion.value`)
- [ ] macOS matrix passes `MultiPayloadEnumTests` with no signal-11
- [ ] macOS matrix passes `GenericSpecializationTests`, `GenericSpecializerAPITests`, `MetadataReaderDemanglingTests`
- [ ] `swift test --filter MachOSwiftSectionTests` green
- [ ] Tagging `0.10.1` cuts a clean release (release.yml verification step passes)