### PR TITLE
fix(swift-sections): guard SymbolIndexStore race + align section readers with ABI

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -89,11 +89,13 @@ jobs:
           swift test \
             -c debug \
             --build-path .build-test-debug \
-            --filter '\.(SymbolTestsCoreDumpSnapshotTests|SymbolTestsCoreInterfaceSnapshotTests|SymbolTestsCoreCoverageInvariantTests|STCoreE2ETests|STCoreTests|GenericSpecializationTests|GenericSpecializerAPITests|MultiPayloadEnumTests|MetadataReaderDemanglingTests)(/|$)'
+            --no-parallel \
+            --filter '\.(SymbolTestsCoreDumpSnapshotTests|SymbolTestsCoreInterfaceSnapshotTests|SymbolTestsCoreCoverageInvariantTests|STCoreE2ETests|STCoreTests|GenericSpecializationTests|MultiPayloadEnumTests|MetadataReaderDemanglingTests)(/|$)'
 
       - name: Build and run tests in release mode
         run: |
           swift test \
             -c release \
             --build-path .build-test-release \
-            --filter '\.(SymbolTestsCoreDumpSnapshotTests|SymbolTestsCoreInterfaceSnapshotTests|SymbolTestsCoreCoverageInvariantTests|STCoreE2ETests|STCoreTests|GenericSpecializationTests|GenericSpecializerAPITests|MultiPayloadEnumTests|MetadataReaderDemanglingTests)(/|$)'
+            --no-parallel \
+            --filter '\.(SymbolTestsCoreDumpSnapshotTests|SymbolTestsCoreInterfaceSnapshotTests|SymbolTestsCoreCoverageInvariantTests|STCoreE2ETests|STCoreTests|GenericSpecializationTests|MultiPayloadEnumTests|MetadataReaderDemanglingTests)(/|$)'

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -89,7 +89,6 @@ jobs:
           swift test \
             -c debug \
             --build-path .build-test-debug \
-            --no-parallel \
             --filter '\.(SymbolTestsCoreDumpSnapshotTests|SymbolTestsCoreInterfaceSnapshotTests|SymbolTestsCoreCoverageInvariantTests|STCoreE2ETests|STCoreTests|GenericSpecializationTests|MultiPayloadEnumTests|MetadataReaderDemanglingTests)(/|$)'
 
       - name: Build and run tests in release mode
@@ -97,5 +96,4 @@ jobs:
           swift test \
             -c release \
             --build-path .build-test-release \
-            --no-parallel \
             --filter '\.(SymbolTestsCoreDumpSnapshotTests|SymbolTestsCoreInterfaceSnapshotTests|SymbolTestsCoreCoverageInvariantTests|STCoreE2ETests|STCoreTests|GenericSpecializationTests|MultiPayloadEnumTests|MetadataReaderDemanglingTests)(/|$)'

--- a/Sources/MachOPointers/Protocol/RelativeDirectPointerIntPairProtocol.swift
+++ b/Sources/MachOPointers/Protocol/RelativeDirectPointerIntPairProtocol.swift
@@ -1,0 +1,27 @@
+import MachOKit
+import MachOReading
+import MachOExtensions
+
+public protocol RelativeDirectPointerIntPairProtocol<Pointee>: RelativeDirectPointerProtocol {
+    typealias Integer = Value.RawValue
+    associatedtype Value: RawRepresentable where Value.RawValue: FixedWidthInteger
+    var relativeOffsetPlusInt: Offset { get }
+}
+
+extension RelativeDirectPointerIntPairProtocol {
+    public var relativeOffset: Offset {
+        relativeOffsetPlusInt & ~mask
+    }
+
+    public var mask: Offset {
+        Offset(MemoryLayout<Offset>.alignment - 1)
+    }
+
+    public var intValue: Integer {
+        numericCast(relativeOffsetPlusInt & mask)
+    }
+
+    public var value: Value {
+        return Value(rawValue: intValue)!
+    }
+}

--- a/Sources/MachOPointers/RelativePointers.swift
+++ b/Sources/MachOPointers/RelativePointers.swift
@@ -8,6 +8,10 @@ public typealias RelativeDirectPointer<Pointee: Resolvable> = TargetRelativeDire
 
 public typealias RelativeDirectRawPointer = TargetRelativeDirectPointer<AnyResolvable, RelativeOffset>
 
+public typealias RelativeDirectPointerIntPair<Pointee: Resolvable, Integer: RawRepresentable> = TargetRelativeDirectPointerIntPair<Pointee, RelativeOffset, Integer> where Integer.RawValue: FixedWidthInteger
+
+public typealias RelativeDirectRawPointerIntPair<Integer: RawRepresentable> = TargetRelativeDirectPointerIntPair<AnyResolvable, RelativeOffset, Integer> where Integer.RawValue: FixedWidthInteger
+
 public typealias RelativeIndirectPointer<Pointee: Resolvable, IndirectType: RelativeIndirectType> = TargetRelativeIndirectPointer<Pointee, RelativeOffset, IndirectType> where Pointee == IndirectType.Resolved
 
 public typealias RelativeIndirectRawPointer = TargetRelativeIndirectPointer<AnyResolvable, RelativeOffset, Pointer<AnyResolvable>>

--- a/Sources/MachOPointers/TargetRelativeDirectPointerIntPair.swift
+++ b/Sources/MachOPointers/TargetRelativeDirectPointerIntPair.swift
@@ -1,0 +1,11 @@
+import MachOReading
+import MachOResolving
+import MachOExtensions
+
+public struct TargetRelativeDirectPointerIntPair<Pointee: Resolvable, Offset: FixedWidthInteger & SignedInteger & Sendable, Value: RawRepresentable>: RelativeDirectPointerIntPairProtocol where Value.RawValue: FixedWidthInteger {
+    public let relativeOffsetPlusInt: Offset
+
+    public init(relativeOffsetPlusInt: Offset) {
+        self.relativeOffsetPlusInt = relativeOffsetPlusInt
+    }
+}

--- a/Sources/MachOSwiftSection/MachOFile+Swift.swift
+++ b/Sources/MachOSwiftSection/MachOFile+Swift.swift
@@ -121,3 +121,6 @@ extension MachOFile.Swift {
 }
 
 extension RelativeDirectPointer: LayoutProtocol {}
+extension RelativeIndirectPointer: LayoutProtocol {}
+extension RelativeIndirectablePointer: LayoutProtocol {}
+extension RelativeIndirectablePointerIntPair: LayoutProtocol {}

--- a/Sources/MachOSwiftSection/MachOFile+Swift.swift
+++ b/Sources/MachOSwiftSection/MachOFile+Swift.swift
@@ -47,7 +47,7 @@ extension MachOFile.Swift: SwiftSectionRepresentable {
 
     public var contextDescriptors: [ContextDescriptorWrapper] {
         get throws {
-            return try _readRelativeDescriptors(from: .__swift5_types, in: machO) + (try? _readRelativeDescriptors(from: .__swift5_types2, in: machO))
+            return try _readTypeMetadataRecords(from: .__swift5_types, in: machO) + (try? _readTypeMetadataRecords(from: .__swift5_types2, in: machO))
         }
     }
 
@@ -59,7 +59,7 @@ extension MachOFile.Swift: SwiftSectionRepresentable {
 
     public var protocolDescriptors: [ProtocolDescriptor] {
         get throws {
-            return try _readRelativeDescriptors(from: .__swift5_protos, in: machO)
+            return try _readProtocolRecords(from: .__swift5_protos, in: machO)
         }
     }
 
@@ -116,11 +116,32 @@ extension MachOFile.Swift {
             section.offset
         }
         let data: [AnyLocatableLayoutWrapper<RelativeDirectPointer<Descriptor>>] = try machO.readWrapperElements(offset: offset, numberOfElements: section.size / pointerSize)
-        return data.compactMap { try? $0.layout.resolve(from: $0.offset, in: machO) }
+        return try data.map { try $0.layout.resolve(from: $0.offset, in: machO) }
+    }
+
+    private func _readTypeMetadataRecords(from swiftMachOSection: MachOSwiftSectionName, in machO: MachOFile) throws -> [ContextDescriptorWrapper] {
+        let section = try machO.section(for: swiftMachOSection)
+        let offset = if let cache = machO.cache {
+            section.address - cache.mainCacheHeader.sharedRegionStart.cast()
+        } else {
+            section.offset
+        }
+        let recordSize = MemoryLayout<TypeMetadataRecord.Layout>.size
+        let records: [TypeMetadataRecord] = try machO.readWrapperElements(offset: offset, numberOfElements: section.size / recordSize)
+        return try records.compactMap { try $0.contextDescriptor(in: machO) }
+    }
+
+    private func _readProtocolRecords(from swiftMachOSection: MachOSwiftSectionName, in machO: MachOFile) throws -> [ProtocolDescriptor] {
+        let section = try machO.section(for: swiftMachOSection)
+        let offset = if let cache = machO.cache {
+            section.address - cache.mainCacheHeader.sharedRegionStart.cast()
+        } else {
+            section.offset
+        }
+        let recordSize = MemoryLayout<ProtocolRecord.Layout>.size
+        let records: [ProtocolRecord] = try machO.readWrapperElements(offset: offset, numberOfElements: section.size / recordSize)
+        return try records.compactMap { try $0.protocolDescriptor(in: machO) }
     }
 }
 
 extension RelativeDirectPointer: LayoutProtocol {}
-extension RelativeIndirectPointer: LayoutProtocol {}
-extension RelativeIndirectablePointer: LayoutProtocol {}
-extension RelativeIndirectablePointerIntPair: LayoutProtocol {}

--- a/Sources/MachOSwiftSection/MachOImage+Swift.swift
+++ b/Sources/MachOSwiftSection/MachOImage+Swift.swift
@@ -110,8 +110,11 @@ extension MachOImage.Swift {
         let vmaddrSlide = try required(machO.vmaddrSlide)
         let start = try required(UnsafeRawPointer(bitPattern: section.address + vmaddrSlide))
         let offset = start.bitPattern.int - machO.ptr.bitPattern.int
-        let pointerSize: Int = MemoryLayout<RelativeDirectPointer<Descriptor>>.size
-        let data: [AnyLocatableLayoutWrapper<RelativeDirectPointer<Descriptor>>] = try machO.readWrapperElements(offset: offset, numberOfElements: section.size / pointerSize)
+        typealias P = RelativeIndirectablePointer<Descriptor, Pointer<Descriptor>>
+        let pointerSize: Int = MemoryLayout<P>.size
+        let data: [AnyLocatableLayoutWrapper<P>] = try machO.readWrapperElements(offset: offset, numberOfElements: section.size / pointerSize)
         return try data.map { try $0.layout.resolve(from: $0.offset, in: machO) }
     }
 }
+
+

--- a/Sources/MachOSwiftSection/MachOImage+Swift.swift
+++ b/Sources/MachOSwiftSection/MachOImage+Swift.swift
@@ -47,7 +47,7 @@ extension MachOImage.Swift: SwiftSectionRepresentable {
 
     public var contextDescriptors: [ContextDescriptorWrapper] {
         get throws {
-            return try _readRelativeDescriptors(from: .__swift5_types, in: machO) + (try? _readRelativeDescriptors(from: .__swift5_types2, in: machO))
+            return try _readTypeMetadataRecords(from: .__swift5_types, in: machO) + (try? _readTypeMetadataRecords(from: .__swift5_types2, in: machO))
         }
     }
 
@@ -59,7 +59,7 @@ extension MachOImage.Swift: SwiftSectionRepresentable {
 
     public var protocolDescriptors: [ProtocolDescriptor] {
         get throws {
-            return try _readRelativeDescriptors(from: .__swift5_protos, in: machO)
+            return try _readProtocolRecords(from: .__swift5_protos, in: machO)
         }
     }
 
@@ -110,10 +110,29 @@ extension MachOImage.Swift {
         let vmaddrSlide = try required(machO.vmaddrSlide)
         let start = try required(UnsafeRawPointer(bitPattern: section.address + vmaddrSlide))
         let offset = start.bitPattern.int - machO.ptr.bitPattern.int
-        typealias P = RelativeIndirectablePointer<Descriptor, Pointer<Descriptor>>
-        let pointerSize: Int = MemoryLayout<P>.size
-        let data: [AnyLocatableLayoutWrapper<P>] = try machO.readWrapperElements(offset: offset, numberOfElements: section.size / pointerSize)
+        let pointerSize: Int = MemoryLayout<RelativeDirectPointer<Descriptor>>.size
+        let data: [AnyLocatableLayoutWrapper<RelativeDirectPointer<Descriptor>>] = try machO.readWrapperElements(offset: offset, numberOfElements: section.size / pointerSize)
         return try data.map { try $0.layout.resolve(from: $0.offset, in: machO) }
+    }
+
+    private func _readTypeMetadataRecords(from swiftMachOSection: MachOSwiftSectionName, in machO: MachOImage) throws -> [ContextDescriptorWrapper] {
+        let section = try machO.section(for: swiftMachOSection)
+        let vmaddrSlide = try required(machO.vmaddrSlide)
+        let start = try required(UnsafeRawPointer(bitPattern: section.address + vmaddrSlide))
+        let offset = start.bitPattern.int - machO.ptr.bitPattern.int
+        let recordSize = MemoryLayout<TypeMetadataRecord.Layout>.size
+        let records: [TypeMetadataRecord] = try machO.readWrapperElements(offset: offset, numberOfElements: section.size / recordSize)
+        return try records.compactMap { try $0.contextDescriptor(in: machO) }
+    }
+
+    private func _readProtocolRecords(from swiftMachOSection: MachOSwiftSectionName, in machO: MachOImage) throws -> [ProtocolDescriptor] {
+        let section = try machO.section(for: swiftMachOSection)
+        let vmaddrSlide = try required(machO.vmaddrSlide)
+        let start = try required(UnsafeRawPointer(bitPattern: section.address + vmaddrSlide))
+        let offset = start.bitPattern.int - machO.ptr.bitPattern.int
+        let recordSize = MemoryLayout<ProtocolRecord.Layout>.size
+        let records: [ProtocolRecord] = try machO.readWrapperElements(offset: offset, numberOfElements: section.size / recordSize)
+        return try records.compactMap { try $0.protocolDescriptor(in: machO) }
     }
 }
 

--- a/Sources/MachOSwiftSection/Models/Protocol/ProtocolRecord.swift
+++ b/Sources/MachOSwiftSection/Models/Protocol/ProtocolRecord.swift
@@ -1,0 +1,34 @@
+import Foundation
+import MachOKit
+import MachOFoundation
+
+/// Mirrors `TargetProtocolRecord` from
+/// `swift/include/swift/ABI/Metadata.h:2766`. One entry per 4-byte slot of
+/// `__swift5_protos`.
+///
+/// The C++ declaration stores a single
+/// `RelativeContextPointerIntPair<Runtime, bool, TargetProtocolDescriptor>`
+/// (`MetadataRef.h:109` — a `RelativeIndirectablePointerIntPair` with
+/// `nullable=true`). The low bit is the indirect flag handled by the pointer
+/// itself; the next bit ("reserved for future use", see
+/// `Metadata.h:2769`) is exposed via `Bit` and currently ignored by the
+/// runtime (`MetadataLookup.cpp:821` only calls `getPointer()`).
+public struct ProtocolRecord: ResolvableLocatableLayoutWrapper {
+    public struct Layout: LayoutProtocol {
+        public let `protocol`: RelativeIndirectablePointerIntPair<ProtocolDescriptor?, Bit, Pointer<ProtocolDescriptor?>>
+    }
+
+    public let offset: Int
+    public var layout: Layout
+
+    public init(layout: Layout, offset: Int) {
+        self.offset = offset
+        self.layout = layout
+    }
+}
+
+extension ProtocolRecord {
+    public func protocolDescriptor<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO) throws -> ProtocolDescriptor? {
+        try layout.protocol.resolve(from: offset(of: \.protocol), in: machO)
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Type/TypeMetadataRecord.swift
+++ b/Sources/MachOSwiftSection/Models/Type/TypeMetadataRecord.swift
@@ -1,0 +1,52 @@
+import Foundation
+import MachOKit
+import MachOFoundation
+
+/// Mirrors `TargetTypeMetadataRecord` from
+/// `swift/include/swift/ABI/Metadata.h:2720`. One entry per 4-byte slot of
+/// `__swift5_types` / `__swift5_types2`.
+///
+/// In C++ the record is a union over two arms, both
+/// `RelativeDirectPointerIntPair<…, TypeReferenceKind>` with identical
+/// in-memory layout, so a single storage field is enough; the
+/// `TypeReferenceKind` tag picks which arm to resolve at access time.
+public struct TypeMetadataRecord: ResolvableLocatableLayoutWrapper {
+    public struct Layout: LayoutProtocol {
+        public let nominalTypeDescriptor: RelativeDirectPointerIntPair<ContextDescriptorWrapper, TypeReferenceKind>
+    }
+
+    public let offset: Int
+    public var layout: Layout
+
+    public init(layout: Layout, offset: Int) {
+        self.offset = offset
+        self.layout = layout
+    }
+}
+
+extension TypeMetadataRecord {
+    public var typeKind: TypeReferenceKind {
+        return layout.nominalTypeDescriptor.value
+    }
+
+    /// Resolves the referenced context descriptor, branching on
+    /// `TypeReferenceKind` the same way Swift runtime does in
+    /// `TargetTypeMetadataRecord::getContextDescriptor()`
+    /// (`swift/include/swift/ABI/Metadata.h:2743`). ObjC kinds are never
+    /// populated in this section (see the comment at Metadata.h:2751); return
+    /// `nil` for them to mirror the runtime's `nullptr` fallback.
+    public func contextDescriptor<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO) throws -> ContextDescriptorWrapper? {
+        let fieldOffset = offset(of: \.nominalTypeDescriptor)
+        let relativeOffset = layout.nominalTypeDescriptor.relativeOffset
+        switch typeKind {
+        case .directTypeDescriptor:
+            let pointer = RelativeDirectPointer<ContextDescriptorWrapper>(relativeOffset: relativeOffset)
+            return try pointer.resolve(from: fieldOffset, in: machO)
+        case .indirectTypeDescriptor:
+            let pointer = RelativeIndirectPointer<ContextDescriptorWrapper, Pointer<ContextDescriptorWrapper>>(relativeOffset: relativeOffset)
+            return try pointer.resolve(from: fieldOffset, in: machO)
+        case .directObjCClassName, .indirectObjCClass:
+            return nil
+        }
+    }
+}

--- a/Sources/MachOSymbols/SymbolIndexStore.swift
+++ b/Sources/MachOSymbols/SymbolIndexStore.swift
@@ -152,6 +152,7 @@ public final class SymbolIndexStore: SharedCache<SymbolIndexStore.Storage>, @unc
 
         private(set) var symbolsByOffset: OrderedDictionary<Int, [Symbol]> = [:]
 
+        @Mutex
         private(set) var demangledNodeBySymbol: [Symbol: Node] = [:]
 
         private(set) var thunkAttributeMembersByKindAndTypeName: [Node.Kind: [String: [ThunkAttributeMember]]] = [:]

--- a/Tests/SwiftInterfaceTests/GenericSpecializationTests.swift
+++ b/Tests/SwiftInterfaceTests/GenericSpecializationTests.swift
@@ -18,7 +18,6 @@ struct TestGenericStruct<A, B, C> where A: Collection, B: Equatable, C: Hashable
     let c: C
 }
 
-@Suite(.serialized)
 final class GenericSpecializationTests: MachOImageTests, @unchecked Sendable {
     override class var imageName: MachOImageName { .SwiftUICore }
 

--- a/Tests/SwiftInterfaceTests/GenericSpecializationTests.swift
+++ b/Tests/SwiftInterfaceTests/GenericSpecializationTests.swift
@@ -18,6 +18,7 @@ struct TestGenericStruct<A, B, C> where A: Collection, B: Equatable, C: Hashable
     let c: C
 }
 
+@Suite(.serialized)
 final class GenericSpecializationTests: MachOImageTests, @unchecked Sendable {
     override class var imageName: MachOImageName { .SwiftUICore }
 
@@ -72,12 +73,7 @@ final class GenericSpecializationTests: MachOImageTests, @unchecked Sendable {
         )
         try #expect(#require(metadata.value.resolve().struct).fieldOffsets() == [0, 8, 16])
     }
-}
-
-// MARK: - GenericSpecializer API Tests
-
-@Suite
-struct GenericSpecializerAPITests {
+    
     @Test func makeRequest() async throws {
         let machO = MachOImage.current()
 


### PR DESCRIPTION
## Summary

### 1. Data race fix — `SymbolIndexStore` (commit `e61952b`)
Guard `Storage.demangledNodeBySymbol` with `@Mutex` — closes the race documented in `KNOWN_ISSUES.md` under "`SymbolIndexStore.demangledNode(for:in:)` data race under parallel tests". Sibling test suites had been corrupting the unsynchronized `Dictionary`, surfacing non-deterministically as SIGSEGV in the hash lookup, or later as `.invalidContextDescriptor` when the trashed bytes were reinterpreted as context-descriptor flags.

With the mutex in place, `--no-parallel` and `@Suite(.serialized)` are no longer needed — reverted in `67a2824`.

### 2. Swift section reader ABI alignment (commit `67a2824`)
Replace the generic `_readRelativeDescriptors` approach with ABI-accurate wrappers for each section entry type, mirroring `swift/include/swift/ABI/Metadata.h`:

- **`TypeMetadataRecord`** (`Metadata.h:2720`) — struct over `RelativeDirectPointerIntPair<ContextDescriptorWrapper, TypeReferenceKind>`. Resolution branches on the 2-bit `TypeReferenceKind` exactly like `TargetTypeMetadataRecord::getContextDescriptor` does:
  - `DirectTypeDescriptor` → `RelativeDirectPointer`
  - `IndirectTypeDescriptor` → `RelativeIndirectPointer`
  - `DirectObjCClassName` / `IndirectObjCClass` → `nil` (mirrors the runtime `nullptr` fallback at `Metadata.h:2753`, which notes these kinds "are just never used in these lists")
- **`ProtocolRecord`** (`Metadata.h:2766`) — struct over `RelativeIndirectablePointerIntPair<ProtocolDescriptor?, Bit, Pointer<…>>`. `Optional` pointee matches `nullable=true` at `MetadataRef.h:109`; the reserved low-bit tag is exposed via `Bit` (runtime ignores it — see `MetadataLookup.cpp:821` only calling `getPointer()`).
- **`__swift5_proto`** — left on `RelativeDirectPointer<ProtocolConformanceDescriptor>` on both ends to match the naked `using` typealias at `Metadata.h:3054` (no IntPair, no indirect).

#### Infrastructure
- New `RelativeDirectPointerIntPair` / `TargetRelativeDirectPointerIntPair` mirroring `swift/include/swift/Basic/RelativePointer.h:575-619` (low 2 bits = int value, no indirect bit — distinct from the existing `RelativeIndirectablePointerIntPair`).
- Both `MachOFile.Swift` and `MachOImage.Swift` readers now throw strictly (no `try?`), symmetric across ends.
- Drop retroactive `LayoutProtocol` conformances that are no longer reached.

## Test plan

- [x] macOS CI green in both debug and release modes
- [ ] Re-run the macOS workflow 2–3× to confirm stability (the original race was non-deterministic)
- [x] Local `swift build` across the full package
- [ ] Follow-up: move the `SymbolIndexStore.demangledNode(for:in:)` race out of "deferred" in `KNOWN_ISSUES.md`