### PR TITLE
refactor(macho): abstract bind/rebase resolution behind protocol

### DIFF
--- a/Sources/MachOExtensions/MachOBindRebaseResolving.swift
+++ b/Sources/MachOExtensions/MachOBindRebaseResolving.swift
@@ -1,0 +1,26 @@
+import MachOKit
+
+/// Exposes dyld bind / rebase resolution capabilities required when decoding
+/// indirect symbolic references in Swift metadata.
+///
+/// `SymbolOrElementPointer` and other indirect-pointer readers must consult
+/// this protocol before treating the bytes at a relocation site as a literal
+/// virtual address. For files coming straight from disk the bytes are still
+/// chained-fixup encoded; only after binding/rebasing through the dyld
+/// metadata do they become a usable address.
+///
+/// The protocol exists so the resolver code can stay generic over the reading
+/// context and not hard-code `MachOFile`. Wrapper types (e.g. UI-layer
+/// projections that compose a `MachOFile` plus extra state) just forward to
+/// the underlying `MachOFile` to participate in the same dispatch.
+public protocol MachOBindRebaseResolving: Sendable {
+    /// Resolves a bind operation at the given file offset and returns the
+    /// imported symbol name, or `nil` when the offset is not bound.
+    func resolveBind(fileOffset: Int) -> String?
+
+    /// Resolves a rebase operation at the given file offset and returns the
+    /// rebased absolute address, or `nil` when no rebase is recorded.
+    func resolveRebase(fileOffset: Int) -> UInt64?
+}
+
+extension MachOFile: MachOBindRebaseResolving {}

--- a/Sources/MachOReading/ReadingContext/MachOContext.swift
+++ b/Sources/MachOReading/ReadingContext/MachOContext.swift
@@ -81,6 +81,15 @@ public struct MachOContext<MachO: MachORepresentableWithCache & Readable>: Readi
     public func offsetFromAddress(_ address: Int) throws -> Int {
         address
     }
+
+    /// Vends the underlying MachO object as a bind/rebase resolver when it
+    /// conforms to `MachOBindRebaseResolving`. The runtime cast keeps the
+    /// generic parameter `MachO` unconstrained, so wrapper types (e.g.
+    /// UI-layer projections that compose a `MachOFile`) can opt in by
+    /// declaring conformance themselves without changing this site.
+    public var bindRebaseResolver: (any MachOBindRebaseResolving)? {
+        machO as? any MachOBindRebaseResolving
+    }
 }
 
 // MARK: - Convenience Extensions

--- a/Sources/MachOReading/ReadingContext/ReadingContext.swift
+++ b/Sources/MachOReading/ReadingContext/ReadingContext.swift
@@ -239,4 +239,21 @@ public protocol ReadingContext: Sendable {
     /// - Returns: The integer offset representation
     /// - Throws: If the address cannot be converted
     func offsetFromAddress(_ address: Address) throws -> Int
+
+    /// Optional bridge to dyld bind / rebase resolution.
+    ///
+    /// Indirect symbolic references encoded in Swift mangled names point at
+    /// relocation sites whose bytes are still chained-fixup encoded on disk.
+    /// Readers must consult bind / rebase tables before treating those bytes
+    /// as a real address. Contexts that wrap a `MachOFile` return the
+    /// underlying file (or any `MachOBindRebaseResolving` adapter) here;
+    /// contexts that read already-relocated memory (in-process images, etc.)
+    /// return `nil` and the caller falls back to a direct read.
+    var bindRebaseResolver: (any MachOBindRebaseResolving)? { get }
+}
+
+extension ReadingContext {
+    /// Default: no bind/rebase support. Concrete contexts override when they
+    /// can vend a resolver (see `MachOContext`'s implementation).
+    public var bindRebaseResolver: (any MachOBindRebaseResolving)? { nil }
 }

--- a/Sources/MachOSwiftSection/MachOFile+Swift.swift
+++ b/Sources/MachOSwiftSection/MachOFile+Swift.swift
@@ -128,7 +128,14 @@ extension MachOFile.Swift {
         }
         let recordSize = MemoryLayout<TypeMetadataRecord.Layout>.size
         let records: [TypeMetadataRecord] = try machO.readWrapperElements(offset: offset, numberOfElements: section.size / recordSize)
-        return try records.compactMap { try $0.contextDescriptor(in: machO) }
+        return try records.compactMap {
+            do {
+                return try $0.contextDescriptor(in: machO)
+            } catch {
+                print(error)
+                throw error
+            }
+        }
     }
 
     private func _readProtocolRecords(from swiftMachOSection: MachOSwiftSectionName, in machO: MachOFile) throws -> [ProtocolDescriptor] {

--- a/Sources/MachOSwiftSection/MachOFile+Swift.swift
+++ b/Sources/MachOSwiftSection/MachOFile+Swift.swift
@@ -128,14 +128,7 @@ extension MachOFile.Swift {
         }
         let recordSize = MemoryLayout<TypeMetadataRecord.Layout>.size
         let records: [TypeMetadataRecord] = try machO.readWrapperElements(offset: offset, numberOfElements: section.size / recordSize)
-        return try records.compactMap {
-            do {
-                return try $0.contextDescriptor(in: machO)
-            } catch {
-                print(error)
-                throw error
-            }
-        }
+        return try records.compactMap { try $0.contextDescriptor(in: machO) }
     }
 
     private func _readProtocolRecords(from swiftMachOSection: MachOSwiftSectionName, in machO: MachOFile) throws -> [ProtocolDescriptor] {

--- a/Sources/MachOSwiftSection/Models/Type/TypeMetadataRecord.swift
+++ b/Sources/MachOSwiftSection/Models/Type/TypeMetadataRecord.swift
@@ -49,4 +49,19 @@ extension TypeMetadataRecord {
             return nil
         }
     }
+    
+    public func contextDescriptor<Context: ReadingContext>(in context: Context) throws -> ContextDescriptorWrapper? {
+        let fieldOffset = offset(of: \.nominalTypeDescriptor)
+        let relativeOffset = layout.nominalTypeDescriptor.relativeOffset
+        switch typeKind {
+        case .directTypeDescriptor:
+            let pointer = RelativeDirectPointer<ContextDescriptorWrapper>(relativeOffset: relativeOffset)
+            return try pointer.resolve(at: context.addressFromOffset(fieldOffset), in: context)
+        case .indirectTypeDescriptor:
+            let pointer = RelativeIndirectPointer<ContextDescriptorWrapper, Pointer<ContextDescriptorWrapper>>(relativeOffset: relativeOffset)
+            return try pointer.resolve(at: context.addressFromOffset(fieldOffset), in: context)
+        case .directObjCClassName, .indirectObjCClass:
+            return nil
+        }
+    }
 }

--- a/Sources/MachOSymbolPointers/SymbolOrElementPointer.swift
+++ b/Sources/MachOSymbolPointers/SymbolOrElementPointer.swift
@@ -75,20 +75,15 @@ public enum SymbolOrElementPointer<Element: Resolvable>: RelativeIndirectType {
     }
 
     public static func resolve<MachO: MachORepresentableWithCache & Readable>(from offset: Int, in machO: MachO) throws -> Self {
-        if let machOFile = machO as? MachOFile {
-            if let symbol = machOFile.resolveBind(fileOffset: offset) {
+        if let resolver = machO as? any MachOBindRebaseResolving {
+            if let symbol = resolver.resolveBind(fileOffset: offset) {
                 return .symbol(.init(offset: offset, name: symbol))
-            } else {
-                let resolvedFileOffset = offset
-                if let rebase = machOFile.resolveRebase(fileOffset: resolvedFileOffset) {
-                    return .address(rebase)
-                } else {
-                    return try .address(machOFile.readElement(offset: resolvedFileOffset))
-                }
             }
-        } else {
-            return try .address(machO.readElement(offset: offset))
+            if let rebase = resolver.resolveRebase(fileOffset: offset) {
+                return .address(rebase)
+            }
         }
+        return try .address(machO.readElement(offset: offset))
     }
 
     public static func resolve(from ptr: UnsafeRawPointer) throws -> Self {
@@ -96,21 +91,15 @@ public enum SymbolOrElementPointer<Element: Resolvable>: RelativeIndirectType {
     }
 
     public static func resolve<Context: ReadingContext>(at address: Context.Address, in context: Context) throws -> Self {
-        if let machOFileContext = context as? MachOContext<MachOFile> {
-            let machOFile = machOFileContext.machO
+        if let resolver = context.bindRebaseResolver {
             let offset = try context.offsetFromAddress(address)
-            if let symbol = machOFile.resolveBind(fileOffset: offset) {
+            if let symbol = resolver.resolveBind(fileOffset: offset) {
                 return .symbol(.init(offset: offset, name: symbol))
-            } else {
-                let resolvedFileOffset = offset
-                if let rebase = machOFile.resolveRebase(fileOffset: resolvedFileOffset) {
-                    return .address(rebase)
-                } else {
-                    return try .address(machOFile.readElement(offset: resolvedFileOffset))
-                }
             }
-        } else {
-            return try .address(context.readElement(at: address))
+            if let rebase = resolver.resolveRebase(fileOffset: offset) {
+                return .address(rebase)
+            }
         }
+        return try .address(context.readElement(at: address))
     }
 }


### PR DESCRIPTION
## Summary
- Introduce `MachOBindRebaseResolving` so indirect symbolic-reference readers stop hard-casting to `MachOFile`, letting wrapper types (e.g. UI-layer projections that compose a `MachOFile`) opt in by forwarding to the underlying file.
- Expose `bindRebaseResolver` on `ReadingContext` (default `nil`) and on `MachOContext` (runtime cast so the generic `MachO` parameter stays unconstrained), and make `SymbolOrElementPointer.resolve` consult the protocol via context lookup instead of casting.
- Add a generic `contextDescriptor(in:)` overload on `TypeMetadataRecord` to align with the new context-driven resolution path.

## Test plan
- [ ] `swift package update && swift build`
- [ ] `swift test`
- [ ] Spot-check a binary via `swift run swift-section dump <path>` to confirm indirect symbolic references still resolve through bind/rebase.