### PR TITLE
feat(MachOSwiftSection): introduce ReadingContext API

### DIFF
--- a/Sources/MachOReading/ReadingContext/InProcessContext.swift
+++ b/Sources/MachOReading/ReadingContext/InProcessContext.swift
@@ -89,3 +89,13 @@ public struct InProcessContext: ReadingContext, Sendable {
         Int(bitPattern: address)
     }
 }
+
+// MARK: - Runtime Pointer Support
+
+extension InProcessContext {
+    /// In-process addresses are already runtime pointers, so this returns
+    /// the address unchanged.
+    public func runtimePointer(at address: UnsafeRawPointer) throws -> UnsafeRawPointer? {
+        address
+    }
+}

--- a/Sources/MachOReading/ReadingContext/MachOContext.swift
+++ b/Sources/MachOReading/ReadingContext/MachOContext.swift
@@ -110,3 +110,17 @@ extension MachORepresentableWithCache where Self: Readable {
         MachOContext(self)
     }
 }
+
+// MARK: - Runtime Pointer Support
+
+extension MachOContext {
+    /// Returns the runtime pointer for the given file offset when the
+    /// underlying reader is a `MachOImage` mapped into the current process.
+    /// Returns `nil` for `MachOFile` and other non-resident readers.
+    public func runtimePointer(at address: Int) throws -> UnsafeRawPointer? {
+        if let machOImage = machO as? MachOImage {
+            return machOImage.ptr + UnsafeRawPointer.Stride(address)
+        }
+        return nil
+    }
+}

--- a/Sources/MachOReading/ReadingContext/ReadingContext.swift
+++ b/Sources/MachOReading/ReadingContext/ReadingContext.swift
@@ -257,3 +257,20 @@ extension ReadingContext {
     /// can vend a resolver (see `MachOContext`'s implementation).
     public var bindRebaseResolver: (any MachOBindRebaseResolving)? { nil }
 }
+
+extension ReadingContext {
+    /// Converts a context-specific address to a runtime `UnsafeRawPointer`,
+    /// when this context is mapped into the current process.
+    ///
+    /// - `InProcessContext`: returns the address itself (already a pointer).
+    /// - `MachOContext<MachOImage>`: returns `machO.ptr + address`.
+    /// - `MachOContext<MachOFile>` / other readers: returns `nil`.
+    ///
+    /// This is an extension method (not a protocol requirement) so adding
+    /// new `ReadingContext` conformers does not become a breaking change.
+    /// Concrete contexts that *can* vend a runtime pointer override this in
+    /// their own files.
+    public func runtimePointer(at address: Address) throws -> UnsafeRawPointer? {
+        nil
+    }
+}

--- a/Sources/MachOReading/ReadingContext/ReadingContext.swift
+++ b/Sources/MachOReading/ReadingContext/ReadingContext.swift
@@ -118,7 +118,7 @@ extension UnsafeRawPointer: AddressArithmetic {}
 /// // Use with in-process memory
 /// let desc2 = try readDescriptor(at: ptr, in: InProcessContext.shared)
 /// ```
-public protocol ReadingContext: Sendable {
+public protocol ReadingContext<Runtime, Address>: Sendable {
     /// The runtime target this context operates on.
     associatedtype Runtime: RuntimeProtocol
 
@@ -250,6 +250,19 @@ public protocol ReadingContext: Sendable {
     /// contexts that read already-relocated memory (in-process images, etc.)
     /// return `nil` and the caller falls back to a direct read.
     var bindRebaseResolver: (any MachOBindRebaseResolving)? { get }
+
+    /// Converts a context-specific address to a runtime `UnsafeRawPointer`,
+    /// when this context is mapped into the current process.
+    ///
+    /// - `InProcessContext`: returns the address itself (already a pointer).
+    /// - `MachOContext<MachOImage>`: returns `machO.ptr + address`.
+    /// - `MachOContext<MachOFile>` / other readers: returns `nil`.
+    ///
+    /// Declared as a protocol requirement (with a default `nil` implementation
+    /// in the extension below) so existential `any ReadingContext` calls
+    /// dynamic-dispatch to the concrete context's override. The default keeps
+    /// adding new conformers non-breaking.
+    func runtimePointer(at address: Address) throws -> UnsafeRawPointer?
 }
 
 extension ReadingContext {
@@ -259,17 +272,9 @@ extension ReadingContext {
 }
 
 extension ReadingContext {
-    /// Converts a context-specific address to a runtime `UnsafeRawPointer`,
-    /// when this context is mapped into the current process.
-    ///
-    /// - `InProcessContext`: returns the address itself (already a pointer).
-    /// - `MachOContext<MachOImage>`: returns `machO.ptr + address`.
-    /// - `MachOContext<MachOFile>` / other readers: returns `nil`.
-    ///
-    /// This is an extension method (not a protocol requirement) so adding
-    /// new `ReadingContext` conformers does not become a breaking change.
-    /// Concrete contexts that *can* vend a runtime pointer override this in
-    /// their own files.
+    /// Default: contexts that aren't mapped into the current process can't
+    /// vend a runtime pointer. Concrete contexts override this in their own
+    /// files (`InProcessContext`, `MachOContext`).
     public func runtimePointer(at address: Address) throws -> UnsafeRawPointer? {
         nil
     }

--- a/Sources/MachOSwiftSection/Models/Anonymous/AnonymousContext.swift
+++ b/Sources/MachOSwiftSection/Models/Anonymous/AnonymousContext.swift
@@ -49,3 +49,27 @@ public struct AnonymousContext: TopLevelType, ContextProtocol {
         }
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension AnonymousContext {
+    public init<Context: ReadingContext>(descriptor: AnonymousContextDescriptor, in context: Context) throws {
+        self.descriptor = descriptor
+        var currentOffset = descriptor.offset + descriptor.layoutSize
+
+        let genericContext = try descriptor.genericContext(in: context)
+        if let genericContext {
+            currentOffset += genericContext.size
+        }
+        self.genericContext = genericContext
+
+        if descriptor.hasMangledName {
+            let mangledNamePointerAddress = try context.addressFromOffset(currentOffset)
+            let mangledNamePointer: RelativeDirectPointer<MangledName> = try context.readElement(at: mangledNamePointerAddress)
+            self.mangledName = try mangledNamePointer.resolve(at: mangledNamePointerAddress, in: context)
+            currentOffset += MemoryLayout<RelativeDirectPointer<MangledName>>.size
+        } else {
+            self.mangledName = nil
+        }
+    }
+}

--- a/Sources/MachOSwiftSection/Models/AssociatedType/AssociatedType.swift
+++ b/Sources/MachOSwiftSection/Models/AssociatedType/AssociatedType.swift
@@ -25,3 +25,14 @@ public struct AssociatedType: TopLevelType {
         self.records = try descriptor.associatedTypeRecords()
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension AssociatedType {
+    public init<Context: ReadingContext>(descriptor: AssociatedTypeDescriptor, in context: Context) throws {
+        self.descriptor = descriptor
+        self.conformingTypeName = try descriptor.conformingTypeName(in: context)
+        self.protocolTypeName = try descriptor.protocolTypeName(in: context)
+        self.records = try descriptor.associatedTypeRecords(in: context)
+    }
+}

--- a/Sources/MachOSwiftSection/Models/AssociatedType/AssociatedTypeDescriptor.swift
+++ b/Sources/MachOSwiftSection/Models/AssociatedType/AssociatedTypeDescriptor.swift
@@ -50,3 +50,19 @@ extension AssociatedTypeDescriptor {
 extension AssociatedTypeDescriptor: TopLevelDescriptor {
     public var actualSize: Int { layoutSize + (layout.numAssociatedTypes * layout.associatedTypeRecordSize).cast() }
 }
+
+// MARK: - ReadingContext Support
+
+extension AssociatedTypeDescriptor {
+    public func conformingTypeName<Context: ReadingContext>(in context: Context) throws -> MangledName {
+        return try layout.conformingTypeName.resolve(at: try context.addressFromOffset(offset(of: \.conformingTypeName)), in: context)
+    }
+
+    public func protocolTypeName<Context: ReadingContext>(in context: Context) throws -> MangledName {
+        return try layout.protocolTypeName.resolve(at: try context.addressFromOffset(offset(of: \.protocolTypeName)), in: context)
+    }
+
+    public func associatedTypeRecords<Context: ReadingContext>(in context: Context) throws -> [AssociatedTypeRecord] {
+        return try context.readWrapperElements(at: try context.addressFromOffset(offset + layoutSize), numberOfElements: layout.numAssociatedTypes.cast())
+    }
+}

--- a/Sources/MachOSwiftSection/Models/AssociatedType/AssociatedTypeRecord.swift
+++ b/Sources/MachOSwiftSection/Models/AssociatedType/AssociatedTypeRecord.swift
@@ -37,3 +37,15 @@ extension AssociatedTypeRecord {
         return try layout.substitutedTypeName.resolve(from: pointer(of: \.substitutedTypeName))
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension AssociatedTypeRecord {
+    public func name<Context: ReadingContext>(in context: Context) throws -> String {
+        return try layout.name.resolve(at: try context.addressFromOffset(offset(of: \.name)), in: context)
+    }
+
+    public func substitutedTypeName<Context: ReadingContext>(in context: Context) throws -> MangledName {
+        return try layout.substitutedTypeName.resolve(at: try context.addressFromOffset(offset(of: \.substitutedTypeName)), in: context)
+    }
+}

--- a/Sources/MachOSwiftSection/Models/BuiltinType/BuiltinType.swift
+++ b/Sources/MachOSwiftSection/Models/BuiltinType/BuiltinType.swift
@@ -18,3 +18,12 @@ public struct BuiltinType: TopLevelType {
         self.typeName = try descriptor.typeName()
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension BuiltinType {
+    public init<Context: ReadingContext>(descriptor: BuiltinTypeDescriptor, in context: Context) throws {
+        self.descriptor = descriptor
+        self.typeName = try descriptor.typeName(in: context)
+    }
+}

--- a/Sources/MachOSwiftSection/Models/BuiltinType/BuiltinTypeDescriptor.swift
+++ b/Sources/MachOSwiftSection/Models/BuiltinType/BuiltinTypeDescriptor.swift
@@ -42,3 +42,11 @@ extension BuiltinTypeDescriptor {
         layout.typeName.isNull == false
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension BuiltinTypeDescriptor {
+    public func typeName<Context: ReadingContext>(in context: Context) throws -> MangledName? {
+        return try layout.typeName.resolve(at: try context.addressFromOffset(offset(of: \.typeName)), in: context)
+    }
+}

--- a/Sources/MachOSwiftSection/Models/ContextDescriptor/ContextDescriptorProtocol.swift
+++ b/Sources/MachOSwiftSection/Models/ContextDescriptor/ContextDescriptorProtocol.swift
@@ -16,6 +16,8 @@ public protocol ContextDescriptorProtocol: ResolvableLocatableLayoutWrapper wher
 
     func genericContext<Context: ReadingContext>(in context: Context) throws -> GenericContext?
     func parent<Context: ReadingContext>(in context: Context) throws -> SymbolOrElement<ContextDescriptorWrapper>?
+    func moduleContextDesciptor<Context: ReadingContext>(in context: Context) throws -> (any ModuleContextDescriptorProtocol)?
+    func isCImportedContextDescriptor<Context: ReadingContext>(in context: Context) throws -> Bool
 
     subscript<T>(dynamicMember keyPath: KeyPath<ContextDescriptorFlags, T>) -> T { get }
 }
@@ -104,5 +106,26 @@ extension ContextDescriptorProtocol {
     public func genericContext<Context: ReadingContext>(in context: Context) throws -> GenericContext? {
         guard layout.flags.isGeneric else { return nil }
         return try GenericContext(contextDescriptor: self, in: context)
+    }
+
+    public func moduleContextDesciptor<Context: ReadingContext>(in context: Context) throws -> (any ModuleContextDescriptorProtocol)? {
+        if let module = self as? (any ModuleContextDescriptorProtocol) {
+            return module
+        } else {
+            var parent: SymbolOrElement<ContextDescriptorWrapper>? = try parent(in: context)
+            while let currentParent = parent {
+                if let module = currentParent.resolved?.contextDescriptor as? (any ModuleContextDescriptorProtocol) {
+                    return module
+                }
+                parent = try currentParent.resolved?.parent(in: context)
+            }
+            return nil
+        }
+    }
+
+    public func isCImportedContextDescriptor<Context: ReadingContext>(in context: Context) throws -> Bool {
+        guard let moduleContextDescriptor = try moduleContextDesciptor(in: context) else { return false }
+        let moduleName = try moduleContextDescriptor.name(in: context)
+        return moduleName == cModule || moduleName == objcModule
     }
 }

--- a/Sources/MachOSwiftSection/Models/ContextDescriptor/ContextDescriptorProtocol.swift
+++ b/Sources/MachOSwiftSection/Models/ContextDescriptor/ContextDescriptorProtocol.swift
@@ -6,17 +6,17 @@ import Demangling
 public protocol ContextDescriptorProtocol: ResolvableLocatableLayoutWrapper where Layout: ContextDescriptorLayout {
     func genericContext<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO) throws -> GenericContext?
     func parent<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO) throws -> SymbolOrElement<ContextDescriptorWrapper>?
-    func moduleContextDesciptor<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO) throws -> (any ModuleContextDescriptorProtocol)?
+    func moduleContextDescriptor<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO) throws -> (any ModuleContextDescriptorProtocol)?
     func isCImportedContextDescriptor<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO) throws -> Bool
 
     func genericContext() throws -> GenericContext?
     func parent() throws -> SymbolOrElement<ContextDescriptorWrapper>?
-    func moduleContextDesciptor() throws -> (any ModuleContextDescriptorProtocol)?
+    func moduleContextDescriptor() throws -> (any ModuleContextDescriptorProtocol)?
     func isCImportedContextDescriptor() throws -> Bool
 
     func genericContext<Context: ReadingContext>(in context: Context) throws -> GenericContext?
     func parent<Context: ReadingContext>(in context: Context) throws -> SymbolOrElement<ContextDescriptorWrapper>?
-    func moduleContextDesciptor<Context: ReadingContext>(in context: Context) throws -> (any ModuleContextDescriptorProtocol)?
+    func moduleContextDescriptor<Context: ReadingContext>(in context: Context) throws -> (any ModuleContextDescriptorProtocol)?
     func isCImportedContextDescriptor<Context: ReadingContext>(in context: Context) throws -> Bool
 
     subscript<T>(dynamicMember keyPath: KeyPath<ContextDescriptorFlags, T>) -> T { get }
@@ -38,7 +38,7 @@ extension ContextDescriptorProtocol {
         return try GenericContext(contextDescriptor: self, in: machO)
     }
 
-    public func moduleContextDesciptor<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO) throws -> (any ModuleContextDescriptorProtocol)? {
+    public func moduleContextDescriptor<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO) throws -> (any ModuleContextDescriptorProtocol)? {
         if let module = self as? (any ModuleContextDescriptorProtocol) {
             return module
         } else {
@@ -54,7 +54,7 @@ extension ContextDescriptorProtocol {
     }
 
     public func isCImportedContextDescriptor<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO) throws -> Bool {
-        guard let moduleContextDescriptor = try moduleContextDesciptor(in: machO) else { return false }
+        guard let moduleContextDescriptor = try moduleContextDescriptor(in: machO) else { return false }
         let moduleName = try moduleContextDescriptor.name(in: machO)
         return moduleName == cModule || moduleName == objcModule
     }
@@ -71,7 +71,7 @@ extension ContextDescriptorProtocol {
         return try GenericContext(contextDescriptor: self)
     }
 
-    public func moduleContextDesciptor() throws -> (any ModuleContextDescriptorProtocol)? {
+    public func moduleContextDescriptor() throws -> (any ModuleContextDescriptorProtocol)? {
         if let module = self as? (any ModuleContextDescriptorProtocol) {
             return module
         } else {
@@ -87,7 +87,7 @@ extension ContextDescriptorProtocol {
     }
 
     public func isCImportedContextDescriptor() throws -> Bool {
-        guard let moduleContextDescriptor = try moduleContextDesciptor() else { return false }
+        guard let moduleContextDescriptor = try moduleContextDescriptor() else { return false }
         let moduleName = try moduleContextDescriptor.name()
         return moduleName == cModule || moduleName == objcModule
     }
@@ -108,7 +108,7 @@ extension ContextDescriptorProtocol {
         return try GenericContext(contextDescriptor: self, in: context)
     }
 
-    public func moduleContextDesciptor<Context: ReadingContext>(in context: Context) throws -> (any ModuleContextDescriptorProtocol)? {
+    public func moduleContextDescriptor<Context: ReadingContext>(in context: Context) throws -> (any ModuleContextDescriptorProtocol)? {
         if let module = self as? (any ModuleContextDescriptorProtocol) {
             return module
         } else {
@@ -124,7 +124,7 @@ extension ContextDescriptorProtocol {
     }
 
     public func isCImportedContextDescriptor<Context: ReadingContext>(in context: Context) throws -> Bool {
-        guard let moduleContextDescriptor = try moduleContextDesciptor(in: context) else { return false }
+        guard let moduleContextDescriptor = try moduleContextDescriptor(in: context) else { return false }
         let moduleName = try moduleContextDescriptor.name(in: context)
         return moduleName == cModule || moduleName == objcModule
     }

--- a/Sources/MachOSwiftSection/Models/ContextDescriptor/ContextProtocol.swift
+++ b/Sources/MachOSwiftSection/Models/ContextDescriptor/ContextProtocol.swift
@@ -12,8 +12,16 @@ extension ContextProtocol {
     public func parent(in machO: some MachOSwiftSectionRepresentableWithCache) throws -> SymbolOrElement<ContextWrapper>? {
         try descriptor.parent(in: machO)?.map { try ContextWrapper.forContextDescriptorWrapper($0, in: machO) }
     }
-    
+
     public func parent() throws -> SymbolOrElement<ContextWrapper>? {
         try descriptor.parent()?.map { try ContextWrapper.forContextDescriptorWrapper($0) }
+    }
+}
+
+// MARK: - ReadingContext Support
+
+extension ContextProtocol {
+    public func parent<Context: ReadingContext>(in context: Context) throws -> SymbolOrElement<ContextWrapper>? {
+        try descriptor.parent(in: context)?.map { try ContextWrapper.forContextDescriptorWrapper($0, in: context) }
     }
 }

--- a/Sources/MachOSwiftSection/Models/ContextDescriptor/ContextWrapper.swift
+++ b/Sources/MachOSwiftSection/Models/ContextDescriptor/ContextWrapper.swift
@@ -133,3 +133,55 @@ public enum ContextWrapper: Resolvable {
         }
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension ContextWrapper {
+    public static func forContextDescriptorWrapper<Context: ReadingContext>(_ contextDescriptorWrapper: ContextDescriptorWrapper, in context: Context) throws -> Self {
+        switch contextDescriptorWrapper {
+        case .type(let typeContextDescriptorWrapper):
+            switch typeContextDescriptorWrapper {
+            case .enum(let enumDescriptor):
+                return try .type(.enum(.init(descriptor: enumDescriptor, in: context)))
+            case .struct(let structDescriptor):
+                return try .type(.struct(.init(descriptor: structDescriptor, in: context)))
+            case .class(let classDescriptor):
+                return try .type(.class(.init(descriptor: classDescriptor, in: context)))
+            }
+        case .protocol(let protocolDescriptor):
+            return try .protocol(.init(descriptor: protocolDescriptor, in: context))
+        case .anonymous(let anonymousContextDescriptor):
+            return try .anonymous(.init(descriptor: anonymousContextDescriptor, in: context))
+        case .extension(let extensionContextDescriptor):
+            return try .extension(.init(descriptor: extensionContextDescriptor, in: context))
+        case .module(let moduleContextDescriptor):
+            return try .module(.init(descriptor: moduleContextDescriptor, in: context))
+        case .opaqueType(let opaqueTypeDescriptor):
+            return try .opaqueType(.init(descriptor: opaqueTypeDescriptor, in: context))
+        }
+    }
+
+    public func parent<Context: ReadingContext>(in context: Context) throws -> SymbolOrElement<ContextWrapper>? {
+        switch self {
+        case .type(let typeWrapper):
+            switch typeWrapper {
+            case .enum(let `enum`):
+                return try `enum`.descriptor.parent(in: context)?.map { try ContextWrapper.forContextDescriptorWrapper($0, in: context) }
+            case .struct(let `struct`):
+                return try `struct`.descriptor.parent(in: context)?.map { try ContextWrapper.forContextDescriptorWrapper($0, in: context) }
+            case .class(let `class`):
+                return try `class`.descriptor.parent(in: context)?.map { try ContextWrapper.forContextDescriptorWrapper($0, in: context) }
+            }
+        case .protocol(let `protocol`):
+            return try `protocol`.descriptor.parent(in: context)?.map { try ContextWrapper.forContextDescriptorWrapper($0, in: context) }
+        case .anonymous(let anonymousContext):
+            return try anonymousContext.descriptor.parent(in: context)?.map { try ContextWrapper.forContextDescriptorWrapper($0, in: context) }
+        case .extension(let extensionContext):
+            return try extensionContext.descriptor.parent(in: context)?.map { try ContextWrapper.forContextDescriptorWrapper($0, in: context) }
+        case .module(let moduleContext):
+            return try moduleContext.descriptor.parent(in: context)?.map { try ContextWrapper.forContextDescriptorWrapper($0, in: context) }
+        case .opaqueType(let opaqueType):
+            return try opaqueType.descriptor.parent(in: context)?.map { try ContextWrapper.forContextDescriptorWrapper($0, in: context) }
+        }
+    }
+}

--- a/Sources/MachOSwiftSection/Models/ExistentialType/ExistentialTypeMetadata.swift
+++ b/Sources/MachOSwiftSection/Models/ExistentialType/ExistentialTypeMetadata.swift
@@ -82,3 +82,21 @@ public enum ExistentialTypeRepresentation {
     case `class`
     case error
 }
+
+// MARK: - ReadingContext Support
+
+extension ExistentialTypeMetadata {
+    public func superclassConstraint<Context: ReadingContext>(in context: Context) throws -> ConstMetadataPointer<Metadata>? {
+        guard layout.flags.hasSuperclassConstraint else { return nil }
+        return try .resolve(at: try context.addressFromOffset(offset + layoutSize), in: context)
+    }
+
+    public func protocols<Context: ReadingContext>(in context: Context) throws -> [ProtocolDescriptorRef] {
+        guard layout.numberOfProtocols != .zero else { return [] }
+        var offset = offset + layoutSize
+        if layout.flags.hasSuperclassConstraint {
+            offset.offset(of: ConstMetadataPointer<Metadata>.self)
+        }
+        return try context.readElements(at: try context.addressFromOffset(offset), numberOfElements: layout.numberOfProtocols.cast())
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Extension/ExtensionContext.swift
+++ b/Sources/MachOSwiftSection/Models/Extension/ExtensionContext.swift
@@ -21,3 +21,13 @@ public struct ExtensionContext: TopLevelType, ContextProtocol {
         self.genericContext = try descriptor.genericContext()
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension ExtensionContext {
+    public init<Context: ReadingContext>(descriptor: ExtensionContextDescriptor, in context: Context) throws {
+        self.descriptor = descriptor
+        self.extendedContextMangledName = try descriptor.extendedContext(in: context)
+        self.genericContext = try descriptor.genericContext(in: context)
+    }
+}

--- a/Sources/MachOSwiftSection/Models/FieldDescriptor/FieldDescriptor.swift
+++ b/Sources/MachOSwiftSection/Models/FieldDescriptor/FieldDescriptor.swift
@@ -48,3 +48,17 @@ extension FieldDescriptor {
         return try asPointer.readWrapperElements(offset: offset, numberOfElements: layout.numFields.cast())
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension FieldDescriptor {
+    public func mangledTypeName<Context: ReadingContext>(in context: Context) throws -> MangledName {
+        return try layout.mangledTypeName.resolve(at: try context.addressFromOffset(offset(of: \.mangledTypeName)), in: context)
+    }
+
+    public func records<Context: ReadingContext>(in context: Context) throws -> [FieldRecord] {
+        guard layout.fieldRecordSize != 0 else { return [] }
+        let offset = offset + MemoryLayout<FieldDescriptor.Layout>.size
+        return try context.readWrapperElements(at: try context.addressFromOffset(offset), numberOfElements: layout.numFields.cast())
+    }
+}

--- a/Sources/MachOSwiftSection/Models/FieldRecord/FieldRecord.swift
+++ b/Sources/MachOSwiftSection/Models/FieldRecord/FieldRecord.swift
@@ -38,3 +38,15 @@ extension FieldRecord {
         return try layout.fieldName.resolve(from: pointer(of: \.fieldName))
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension FieldRecord {
+    public func mangledTypeName<Context: ReadingContext>(in context: Context) throws -> MangledName {
+        return try layout.mangledTypeName.resolve(at: try context.addressFromOffset(offset(of: \.mangledTypeName)), in: context)
+    }
+
+    public func fieldName<Context: ReadingContext>(in context: Context) throws -> String {
+        return try layout.fieldName.resolve(at: try context.addressFromOffset(offset(of: \.fieldName)), in: context)
+    }
+}

--- a/Sources/MachOSwiftSection/Models/ForeignType/ForeignClassMetadata.swift
+++ b/Sources/MachOSwiftSection/Models/ForeignType/ForeignClassMetadata.swift
@@ -23,8 +23,16 @@ extension ForeignClassMetadata {
     public func classDescriptor(in machO: some MachOSwiftSectionRepresentableWithCache) throws -> ClassDescriptor {
         try layout.descriptor.resolve(in: machO)
     }
-    
+
     public func classDescriptor() throws -> ClassDescriptor {
         try layout.descriptor.resolve()
+    }
+}
+
+// MARK: - ReadingContext Support
+
+extension ForeignClassMetadata {
+    public func classDescriptor<Context: ReadingContext>(in context: Context) throws -> ClassDescriptor {
+        try layout.descriptor.resolve(in: context)
     }
 }

--- a/Sources/MachOSwiftSection/Models/ForeignType/ForeignReferenceTypeMetadata.swift
+++ b/Sources/MachOSwiftSection/Models/ForeignType/ForeignReferenceTypeMetadata.swift
@@ -27,3 +27,11 @@ extension ForeignReferenceTypeMetadata {
         try layout.descriptor.resolve()
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension ForeignReferenceTypeMetadata {
+    public func classDescriptor<Context: ReadingContext>(in context: Context) throws -> ClassDescriptor {
+        try layout.descriptor.resolve(in: context)
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Generic/GenericContext.swift
+++ b/Sources/MachOSwiftSection/Models/Generic/GenericContext.swift
@@ -391,3 +391,18 @@ extension Array {
         return copy
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension TargetGenericContext {
+    public func uniqueCurrentRequirements<Context: ReadingContext>(in context: Context) -> [GenericRequirementDescriptor] {
+        let parentRequirements = parentRequirements.flatMap { $0 }
+        var currentRequirements: [GenericRequirementDescriptor] = []
+        for requirement in requirements {
+            if !parentRequirements.contains(where: { $0.isContentEqual(to: requirement, in: context) }) {
+                currentRequirements.append(requirement)
+            }
+        }
+        return currentRequirements
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Generic/GenericRequirement.swift
+++ b/Sources/MachOSwiftSection/Models/Generic/GenericRequirement.swift
@@ -21,3 +21,13 @@ public struct GenericRequirement: Sendable, TopLevelType {
         self.content = try descriptor.resolvedContent()
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension GenericRequirement {
+    public init<Context: ReadingContext>(descriptor: GenericRequirementDescriptor, in context: Context) throws {
+        self.descriptor = descriptor
+        self.paramManagledName = try descriptor.paramMangledName(in: context)
+        self.content = try descriptor.resolvedContent(in: context)
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Generic/GenericRequirementDescriptor.swift
+++ b/Sources/MachOSwiftSection/Models/Generic/GenericRequirementDescriptor.swift
@@ -113,6 +113,12 @@ extension GenericRequirementDescriptor {
 // MARK: - ReadingContext Support
 
 extension GenericRequirementDescriptor {
+    public func isContentEqual<Context: ReadingContext>(to other: GenericRequirementDescriptor, in context: Context) -> Bool {
+        guard let lhsResolvedParam = try? paramMangledName(in: context), let rhsResolvedParam = try? other.paramMangledName(in: context) else { return false }
+        guard let lhsResolvedContent = try? resolvedContent(in: context), let rhsResolvedContent = try? other.resolvedContent(in: context) else { return false }
+        return layout.flags == other.flags && lhsResolvedParam == rhsResolvedParam && lhsResolvedContent == rhsResolvedContent
+    }
+
     public func paramMangledName<Context: ReadingContext>(in context: Context) throws -> MangledName {
         let baseAddress = try context.addressFromOffset(offset(of: \.param))
         return try layout.param.resolve(at: baseAddress, in: context)

--- a/Sources/MachOSwiftSection/Models/Metadata/MetadataProtocol.swift
+++ b/Sources/MachOSwiftSection/Models/Metadata/MetadataProtocol.swift
@@ -138,3 +138,54 @@ extension MetadataProtocol where HeaderType: TypeMetadataHeaderBaseProtocol {
         }
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension MetadataProtocol {
+    public func asMetadataWrapper<Context: ReadingContext>(in context: Context) throws -> MetadataWrapper {
+        try .resolve(at: try context.addressFromOffset(offset), in: context)
+    }
+
+    public func asMetadata<Context: ReadingContext>(in context: Context) throws -> Metadata {
+        try .resolve(at: try context.addressFromOffset(offset), in: context)
+    }
+}
+
+extension MetadataProtocol where HeaderType: TypeMetadataHeaderBaseProtocol {
+    public func asFullMetadata<Context: ReadingContext>(in context: Context) throws -> FullMetadata<Self> {
+        try FullMetadata<Self>.resolve(at: try context.addressFromOffset(offset - HeaderType.layoutSize), in: context)
+    }
+
+    public func valueWitnesses<Context: ReadingContext>(in context: Context) throws -> ValueWitnessTable {
+        let fullMetadata = try asFullMetadata(in: context)
+        return try fullMetadata.layout.header.valueWitnesses.resolve(in: context)
+    }
+}
+
+extension MetadataProtocol where HeaderType: TypeMetadataHeaderBaseProtocol {
+    public func typeLayout<Context: ReadingContext>(in context: Context) throws -> TypeLayout {
+        try valueWitnesses(in: context).typeLayout
+    }
+
+    public func typeContextDescriptorWrapper<Context: ReadingContext>(in context: Context) throws -> TypeContextDescriptorWrapper? {
+        switch kind {
+        case .class:
+            let cls = try AnyClassMetadataObjCInterop.resolve(at: try context.addressFromOffset(offset), in: context)
+            if cls.isPureObjC {
+                return nil
+            } else {
+                return try .class(ClassMetadataObjCInterop.resolve(at: try context.addressFromOffset(offset), in: context).descriptor(in: context)!)
+            }
+        case .struct,
+             .enum,
+             .optional:
+            return try ValueMetadata.resolve(at: try context.addressFromOffset(offset), in: context).descriptor(in: context).asTypeContextDescriptorWrapper
+        case .foreignClass:
+            return try .class(ForeignClassMetadata.resolve(at: try context.addressFromOffset(offset), in: context).classDescriptor(in: context))
+        case .foreignReferenceType:
+            return try .class(ForeignReferenceTypeMetadata.resolve(at: try context.addressFromOffset(offset), in: context).classDescriptor(in: context))
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Metadata/MetadataWrapper.swift
+++ b/Sources/MachOSwiftSection/Models/Metadata/MetadataWrapper.swift
@@ -252,7 +252,7 @@ public enum MetadataWrapper: Resolvable {
         case .job:
             return try .job(machO.readWrapperElement(offset: offset))
         case .lastEnumerated:
-            fatalError()
+            throw MachOSwiftSectionError.unknownMetadataKind(rawValue: UInt(metadata.kind.rawValue))
         }
     }
 
@@ -300,7 +300,7 @@ public enum MetadataWrapper: Resolvable {
         case .job:
             return try .job(.resolve(from: ptr))
         case .lastEnumerated:
-            fatalError()
+            throw MachOSwiftSectionError.unknownMetadataKind(rawValue: UInt(metadata.kind.rawValue))
         }
     }
 }
@@ -397,7 +397,7 @@ extension MetadataWrapper {
         case .job:
             return try .job(context.readWrapperElement(at: address))
         case .lastEnumerated:
-            fatalError()
+            throw MachOSwiftSectionError.unknownMetadataKind(rawValue: UInt(metadata.kind.rawValue))
         }
     }
 }

--- a/Sources/MachOSwiftSection/Models/Metadata/MetadataWrapper.swift
+++ b/Sources/MachOSwiftSection/Models/Metadata/MetadataWrapper.swift
@@ -304,3 +304,100 @@ public enum MetadataWrapper: Resolvable {
         }
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension MetadataWrapper {
+    public func valueWitnessTable<Context: ReadingContext>(in context: Context) throws -> ValueWitnessTable {
+        switch self {
+        case .class(let classMetadataObjCInterop):
+            return try classMetadataObjCInterop.asFullMetadata(in: context).valueWitnesses.resolve(in: context)
+        case .struct(let structMetadata):
+            return try structMetadata.asFullMetadata(in: context).valueWitnesses.resolve(in: context)
+        case .enum(let enumMetadata):
+            return try enumMetadata.asFullMetadata(in: context).valueWitnesses.resolve(in: context)
+        case .optional(let enumMetadata):
+            return try enumMetadata.asFullMetadata(in: context).valueWitnesses.resolve(in: context)
+        case .foreignClass(let foreignClassMetadata):
+            return try foreignClassMetadata.asFullMetadata(in: context).valueWitnesses.resolve(in: context)
+        case .foreignReferenceType(let foreignReferenceTypeMetadata):
+            return try foreignReferenceTypeMetadata.asFullMetadata(in: context).valueWitnesses.resolve(in: context)
+        case .opaque(let opaqueMetadata):
+            return try opaqueMetadata.asFullMetadata(in: context).valueWitnesses.resolve(in: context)
+        case .tuple(let tupleTypeMetadata):
+            return try tupleTypeMetadata.asFullMetadata(in: context).valueWitnesses.resolve(in: context)
+        case .function(let functionTypeMetadata):
+            return try functionTypeMetadata.asFullMetadata(in: context).valueWitnesses.resolve(in: context)
+        case .existential(let existentialTypeMetadata):
+            return try existentialTypeMetadata.asFullMetadata(in: context).valueWitnesses.resolve(in: context)
+        case .metatype(let metatypeMetadata):
+            return try metatypeMetadata.asFullMetadata(in: context).valueWitnesses.resolve(in: context)
+        case .objcClassWrapper(let objCClassWrapperMetadata):
+            return try objCClassWrapperMetadata.asFullMetadata(in: context).valueWitnesses.resolve(in: context)
+        case .existentialMetatype(let existentialMetatypeMetadata):
+            return try existentialMetatypeMetadata.asFullMetadata(in: context).valueWitnesses.resolve(in: context)
+        case .extendedExistential(let extendedExistentialTypeMetadata):
+            return try extendedExistentialTypeMetadata.asFullMetadata(in: context).valueWitnesses.resolve(in: context)
+        case .fixedArray(let fixedArrayTypeMetadata):
+            return try fixedArrayTypeMetadata.asFullMetadata(in: context).valueWitnesses.resolve(in: context)
+        case .heapLocalVariable(let heapLocalVariableMetadata):
+            return try heapLocalVariableMetadata.asFullMetadata(in: context).valueWitnesses.resolve(in: context)
+        case .heapGenericLocalVariable(let genericBoxHeapMetadata):
+            return try genericBoxHeapMetadata.asFullMetadata(in: context).valueWitnesses.resolve(in: context)
+        case .errorObject(let enumMetadata):
+            return try enumMetadata.asFullMetadata(in: context).valueWitnesses.resolve(in: context)
+        case .task(let dispatchClassMetadata):
+            return try dispatchClassMetadata.asFullMetadata(in: context).valueWitnesses.resolve(in: context)
+        case .job(let dispatchClassMetadata):
+            return try dispatchClassMetadata.asFullMetadata(in: context).valueWitnesses.resolve(in: context)
+        }
+    }
+
+    public static func resolve<Context: ReadingContext>(at address: Context.Address, in context: Context) throws -> Self {
+        let metadata = try context.readWrapperElement(at: address) as Metadata
+        switch metadata.kind {
+        case .class:
+            return try .class(context.readWrapperElement(at: address))
+        case .struct:
+            return try .struct(context.readWrapperElement(at: address))
+        case .enum:
+            return try .enum(context.readWrapperElement(at: address))
+        case .optional:
+            return try .optional(context.readWrapperElement(at: address))
+        case .foreignClass:
+            return try .foreignClass(context.readWrapperElement(at: address))
+        case .foreignReferenceType:
+            return try .foreignReferenceType(context.readWrapperElement(at: address))
+        case .opaque:
+            return try .opaque(context.readWrapperElement(at: address))
+        case .tuple:
+            return try .tuple(context.readWrapperElement(at: address))
+        case .function:
+            return try .function(context.readWrapperElement(at: address))
+        case .existential:
+            return try .existential(context.readWrapperElement(at: address))
+        case .metatype:
+            return try .metatype(context.readWrapperElement(at: address))
+        case .objcClassWrapper:
+            return try .objcClassWrapper(context.readWrapperElement(at: address))
+        case .existentialMetatype:
+            return try .existentialMetatype(context.readWrapperElement(at: address))
+        case .extendedExistential:
+            return try .extendedExistential(context.readWrapperElement(at: address))
+        case .fixedArray:
+            return try .fixedArray(context.readWrapperElement(at: address))
+        case .heapLocalVariable:
+            return try .heapLocalVariable(context.readWrapperElement(at: address))
+        case .heapGenericLocalVariable:
+            return try .heapGenericLocalVariable(context.readWrapperElement(at: address))
+        case .errorObject:
+            return try .errorObject(context.readWrapperElement(at: address))
+        case .task:
+            return try .task(context.readWrapperElement(at: address))
+        case .job:
+            return try .job(context.readWrapperElement(at: address))
+        case .lastEnumerated:
+            fatalError()
+        }
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Module/ModuleContext.swift
+++ b/Sources/MachOSwiftSection/Models/Module/ModuleContext.swift
@@ -17,3 +17,12 @@ public struct ModuleContext: TopLevelType, ContextProtocol {
         self.name = try descriptor.name()
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension ModuleContext {
+    public init<Context: ReadingContext>(descriptor: ModuleContextDescriptor, in context: Context) throws {
+        self.descriptor = descriptor
+        self.name = try descriptor.name(in: context)
+    }
+}

--- a/Sources/MachOSwiftSection/Models/OpaqueType/OpaqueType.swift
+++ b/Sources/MachOSwiftSection/Models/OpaqueType/OpaqueType.swift
@@ -77,3 +77,38 @@ public struct OpaqueType: TopLevelType, ContextProtocol {
         }
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension OpaqueType {
+    public init<Context: ReadingContext>(descriptor: OpaqueTypeDescriptor, in context: Context) throws {
+        self.descriptor = descriptor
+        var currentOffset = descriptor.offset + descriptor.layoutSize
+
+        let genericContext = try descriptor.genericContext(in: context)
+
+        if let genericContext {
+            currentOffset += genericContext.size
+        }
+        self.genericContext = genericContext
+
+        if descriptor.numUnderlyingTypeArugments > 0 {
+            let underlyingTypeArgumentMangledNamePointers: [RelativeDirectPointer<MangledName>] = try context.readElements(at: try context.addressFromOffset(currentOffset), numberOfElements: descriptor.numUnderlyingTypeArugments)
+            var underlyingTypeArgumentMangledNames: [MangledName] = []
+            for underlyingTypeArgumentMangledNamePointer in underlyingTypeArgumentMangledNamePointers {
+                try underlyingTypeArgumentMangledNames.append(underlyingTypeArgumentMangledNamePointer.resolve(at: try context.addressFromOffset(currentOffset), in: context))
+                currentOffset += MemoryLayout<RelativeDirectPointer<MangledName>>.size
+            }
+            self.underlyingTypeArgumentMangledNames = underlyingTypeArgumentMangledNames
+        } else {
+            self.underlyingTypeArgumentMangledNames = []
+        }
+
+        if descriptor.flags.contains(.hasInvertibleProtocols) {
+            self.invertedProtocols = try context.readElement(at: try context.addressFromOffset(currentOffset)) as InvertibleProtocolSet
+            currentOffset.offset(of: InvertibleProtocolSet.self)
+        } else {
+            self.invertedProtocols = nil
+        }
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Protocol/ObjC/ObjCProtocolPrefix.swift
+++ b/Sources/MachOSwiftSection/Models/Protocol/ObjC/ObjCProtocolPrefix.swift
@@ -39,6 +39,10 @@ extension ObjCProtocolPrefix {
 // MARK: - ReadingContext Support
 
 extension ObjCProtocolPrefix {
+    public func name<Context: ReadingContext>(in context: Context) throws -> String {
+        try layout.name.resolve(in: context)
+    }
+
     public func mangledName<Context: ReadingContext>(in context: Context) throws -> MangledName {
         try layout.name.resolveAny(in: context)
     }

--- a/Sources/MachOSwiftSection/Models/Protocol/Protocol.swift
+++ b/Sources/MachOSwiftSection/Models/Protocol/Protocol.swift
@@ -84,3 +84,38 @@ public struct `Protocol`: TopLevelType, ContextProtocol {
         }
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension `Protocol` {
+    public init<Context: ReadingContext>(descriptor: ProtocolDescriptor, in context: Context) throws {
+        guard let protocolFlags = descriptor.flags.kindSpecificFlags?.protocolFlags else {
+            throw Error.invalidProtocolDescriptor
+        }
+        self.descriptor = descriptor
+        self.protocolFlags = protocolFlags
+        self.name = try descriptor.name(in: context)
+        var currentOffset = descriptor.offset + descriptor.layoutSize
+        if descriptor.numRequirementsInSignature > 0 {
+            let requirementInSignatures = try context.readWrapperElements(at: try context.addressFromOffset(currentOffset), numberOfElements: descriptor.numRequirementsInSignature.cast()) as [GenericRequirementDescriptor]
+            self.requirementInSignatures = try requirementInSignatures.map { try .init(descriptor: $0, in: context) }
+            currentOffset.offset(of: GenericRequirementDescriptor.self, numbersOfElements: descriptor.numRequirementsInSignature.cast())
+            currentOffset.align(to: 4)
+        } else {
+            self.requirementInSignatures = []
+        }
+        try initialize(descriptor: descriptor, currentOffset: &currentOffset, in: context)
+    }
+
+    private mutating func initialize<Context: ReadingContext>(descriptor: ProtocolDescriptor, currentOffset: inout Int, in context: Context) throws {
+        if descriptor.numRequirements > 0 {
+            let baseRequirementOffset = currentOffset - ProtocolRequirement.layoutSize
+            baseRequirement = try context.readWrapperElement(at: try context.addressFromOffset(baseRequirementOffset)) as ProtocolBaseRequirement
+            requirements = try context.readWrapperElements(at: try context.addressFromOffset(currentOffset), numberOfElements: descriptor.numRequirements.cast()) as [ProtocolRequirement]
+            currentOffset.offset(of: ProtocolRequirement.self, numbersOfElements: descriptor.numRequirements.cast())
+        } else {
+            baseRequirement = nil
+            requirements = []
+        }
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Protocol/ProtocolDescriptor.swift
+++ b/Sources/MachOSwiftSection/Models/Protocol/ProtocolDescriptor.swift
@@ -41,3 +41,12 @@ extension ProtocolDescriptor {
         return try layout.associatedTypes.resolve(from: pointer(of: \.associatedTypes)).components(separatedBy: " ")
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension ProtocolDescriptor {
+    public func associatedTypes<Context: ReadingContext>(in context: Context) throws -> [String] {
+        guard layout.associatedTypes.isValid else { return [] }
+        return try layout.associatedTypes.resolve(at: try context.addressFromOffset(offset(of: \.associatedTypes)), in: context).components(separatedBy: " ")
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Protocol/ProtocolDescriptorRef.swift
+++ b/Sources/MachOSwiftSection/Models/Protocol/ProtocolDescriptorRef.swift
@@ -65,3 +65,23 @@ extension ProtocolDescriptorRef {
         }
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension ProtocolDescriptorRef {
+    public func objcProtocol<Context: ReadingContext>(in context: Context) throws -> ObjCProtocolPrefix {
+        try Pointer<ObjCProtocolPrefix>(address: storage & ~Bits.isObjC).resolve(in: context)
+    }
+
+    public func swiftProtocol<Context: ReadingContext>(in context: Context) throws -> ProtocolDescriptor {
+        try Pointer<ProtocolDescriptor>(address: storage).resolve(in: context)
+    }
+
+    public func name<Context: ReadingContext>(in context: Context) throws -> String {
+        if isObjC {
+            return try objcProtocol(in: context).name(in: context)
+        } else {
+            return try swiftProtocol(in: context).name(in: context)
+        }
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Protocol/ProtocolRecord.swift
+++ b/Sources/MachOSwiftSection/Models/Protocol/ProtocolRecord.swift
@@ -32,3 +32,11 @@ extension ProtocolRecord {
         try layout.protocol.resolve(from: offset(of: \.protocol), in: machO)
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension ProtocolRecord {
+    public func protocolDescriptor<Context: ReadingContext>(in context: Context) throws -> ProtocolDescriptor? {
+        try layout.protocol.resolve(at: try context.addressFromOffset(offset(of: \.protocol)), in: context)
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Protocol/ProtocolRequirement.swift
+++ b/Sources/MachOSwiftSection/Models/Protocol/ProtocolRequirement.swift
@@ -36,3 +36,12 @@ public struct ProtocolBaseRequirement: ResolvableLocatableLayoutWrapper {
         self.layout = layout
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension ProtocolRequirement {
+    public func defaultImplementationSymbols<Context: ReadingContext>(in context: Context) throws -> Symbols? {
+        guard layout.defaultImplementation.isValid else { return nil }
+        return try layout.defaultImplementation.resolve(at: try context.addressFromOffset(offset(of: \.defaultImplementation)), in: context)
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Protocol/ResilientWitness.swift
+++ b/Sources/MachOSwiftSection/Models/Protocol/ResilientWitness.swift
@@ -31,6 +31,9 @@ extension ResilientWitness {
         layout.implementation.resolveDirectOffset(from: offset(of: \.implementation))
     }
     
+    /// MachO-only debug formatter; no `ReadingContext` mirror exists because
+    /// `addressString(forOffset:)` is a MachO display helper (not a data read)
+    /// and has no counterpart on the unified `ReadingContext` abstraction.
     public func implementationAddress(in machO: some MachOSwiftSectionRepresentableWithCache) -> String {
         return machO.addressString(forOffset: implementationOffset)
     }

--- a/Sources/MachOSwiftSection/Models/Protocol/ResilientWitness.swift
+++ b/Sources/MachOSwiftSection/Models/Protocol/ResilientWitness.swift
@@ -39,3 +39,15 @@ extension ResilientWitness {
         return try layout.implementation.resolve(from: offset(of: \.implementation), in: machO)
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension ResilientWitness {
+    public func requirement<Context: ReadingContext>(in context: Context) throws -> SymbolOrElement<ProtocolRequirement>? {
+        return try layout.requirement.resolve(at: try context.addressFromOffset(offset(of: \.requirement)), in: context).asOptional
+    }
+
+    public func implementationSymbols<Context: ReadingContext>(in context: Context) throws -> Symbols? {
+        return try layout.implementation.resolve(at: try context.addressFromOffset(offset(of: \.implementation)), in: context)
+    }
+}

--- a/Sources/MachOSwiftSection/Models/ProtocolConformance/GlobalActorReference.swift
+++ b/Sources/MachOSwiftSection/Models/ProtocolConformance/GlobalActorReference.swift
@@ -38,3 +38,11 @@ extension GlobalActorReference {
         try layout.type.resolve(from: pointer(of: \.type))
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension GlobalActorReference {
+    public func typeName<Context: ReadingContext>(in context: Context) throws -> MangledName {
+        try layout.type.resolve(at: try context.addressFromOffset(offset(of: \.type)), in: context)
+    }
+}

--- a/Sources/MachOSwiftSection/Models/ProtocolConformance/ProtocolConformance.swift
+++ b/Sources/MachOSwiftSection/Models/ProtocolConformance/ProtocolConformance.swift
@@ -131,3 +131,72 @@ public struct ProtocolConformance: TopLevelType {
         }
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension ProtocolConformance {
+    public init<Context: ReadingContext>(descriptor: ProtocolConformanceDescriptor, in context: Context) throws {
+        self.descriptor = descriptor
+
+        self.protocol = try descriptor.protocolDescriptor(in: context)
+
+        self.typeReference = try descriptor.resolvedTypeReference(in: context)
+
+        self.witnessTablePattern = try descriptor.witnessTablePattern(in: context)
+
+        var currentOffset = descriptor.offset + descriptor.layoutSize
+
+        if descriptor.flags.isRetroactive {
+            let retroactiveContextPointer: RelativeContextPointer = try context.readElement(at: try context.addressFromOffset(currentOffset))
+            self.retroactiveContextDescriptor = try retroactiveContextPointer.resolve(at: try context.addressFromOffset(currentOffset), in: context).asOptional
+            currentOffset.offset(of: RelativeIndirectablePointer<ContextDescriptorWrapper?, Pointer<ContextDescriptorWrapper?>>.self)
+        } else {
+            self.retroactiveContextDescriptor = nil
+        }
+
+        try initialize(descriptor: descriptor, currentOffset: &currentOffset, in: context)
+    }
+
+    private mutating func initialize<Context: ReadingContext>(descriptor: ProtocolConformanceDescriptor, currentOffset: inout Int, in context: Context) throws {
+        if descriptor.flags.numConditionalRequirements > 0 {
+            conditionalRequirements = try context.readWrapperElements(at: try context.addressFromOffset(currentOffset), numberOfElements: descriptor.flags.numConditionalRequirements.cast()) as [GenericRequirementDescriptor]
+            currentOffset.offset(of: GenericRequirementDescriptor.self, numbersOfElements: descriptor.flags.numConditionalRequirements.cast())
+        } else {
+            conditionalRequirements = []
+        }
+
+        if descriptor.flags.numConditionalPackShapeDescriptors > 0 {
+            conditionalPackShapeDescriptors = try context.readWrapperElements(at: try context.addressFromOffset(currentOffset), numberOfElements: descriptor.flags.numConditionalPackShapeDescriptors.cast()) as [GenericPackShapeDescriptor]
+            currentOffset.offset(of: GenericPackShapeDescriptor.self, numbersOfElements: descriptor.flags.numConditionalPackShapeDescriptors.cast())
+        } else {
+            conditionalPackShapeDescriptors = []
+        }
+
+        if descriptor.flags.hasResilientWitnesses {
+            let header: ResilientWitnessesHeader = try context.readWrapperElement(at: try context.addressFromOffset(currentOffset))
+            resilientWitnessesHeader = header
+            currentOffset.offset(of: ResilientWitnessesHeader.self)
+            resilientWitnesses = try context.readWrapperElements(at: try context.addressFromOffset(currentOffset), numberOfElements: header.numWitnesses.cast()) as [ResilientWitness]
+            currentOffset.offset(of: ResilientWitness.self, numbersOfElements: header.numWitnesses.cast())
+        } else {
+            resilientWitnessesHeader = nil
+            resilientWitnesses = []
+        }
+
+        if descriptor.flags.hasGenericWitnessTable {
+            let genericWitnessTable: GenericWitnessTable = try context.readWrapperElement(at: try context.addressFromOffset(currentOffset))
+            self.genericWitnessTable = genericWitnessTable
+            currentOffset.offset(of: GenericWitnessTable.self)
+        } else {
+            genericWitnessTable = nil
+        }
+
+        if descriptor.flags.hasGlobalActorIsolation {
+            let globalActorReference: GlobalActorReference = try context.readWrapperElement(at: try context.addressFromOffset(currentOffset))
+            self.globalActorReference = globalActorReference
+            currentOffset.offset(of: GlobalActorReference.self)
+        } else {
+            globalActorReference = nil
+        }
+    }
+}

--- a/Sources/MachOSwiftSection/Models/ProtocolConformance/ProtocolConformanceDescriptor.swift
+++ b/Sources/MachOSwiftSection/Models/ProtocolConformance/ProtocolConformanceDescriptor.swift
@@ -54,3 +54,20 @@ extension ProtocolConformanceDescriptor {
         try layout.witnessTablePattern.resolve(from: pointer(of: \.witnessTablePattern))
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension ProtocolConformanceDescriptor {
+    public func protocolDescriptor<Context: ReadingContext>(in context: Context) throws -> SymbolOrElement<ProtocolDescriptor>? {
+        try layout.protocolDescriptor.resolve(at: try context.addressFromOffset(offset(of: \.protocolDescriptor)), in: context).asOptional
+    }
+
+    public func resolvedTypeReference<Context: ReadingContext>(in context: Context) throws -> ResolvedTypeReference {
+        let offset = offset(of: \.typeReference)
+        return try typeReference.resolve(at: offset, in: context)
+    }
+
+    public func witnessTablePattern<Context: ReadingContext>(in context: Context) throws -> ProtocolWitnessTable? {
+        try layout.witnessTablePattern.resolve(at: try context.addressFromOffset(offset(of: \.witnessTablePattern)), in: context)
+    }
+}

--- a/Sources/MachOSwiftSection/Models/TupleType/TupleTypeMetadata.swift
+++ b/Sources/MachOSwiftSection/Models/TupleType/TupleTypeMetadata.swift
@@ -29,8 +29,16 @@ extension TupleTypeMetadata {
     public func elements<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO) throws -> [Element] {
         try machO.readElements(offset: offset + layoutSize, numberOfElements: layout.numberOfElements.cast())
     }
-    
+
     public func elements() throws -> [Element] {
         try asPointer.readElements(offset: layoutSize, numberOfElements: layout.numberOfElements.cast())
+    }
+}
+
+// MARK: - ReadingContext Support
+
+extension TupleTypeMetadata {
+    public func elements<Context: ReadingContext>(in context: Context) throws -> [Element] {
+        try context.readElements(at: try context.addressFromOffset(offset + layoutSize), numberOfElements: layout.numberOfElements.cast())
     }
 }

--- a/Sources/MachOSwiftSection/Models/Type/Class/Class.swift
+++ b/Sources/MachOSwiftSection/Models/Type/Class/Class.swift
@@ -175,3 +175,125 @@ public struct Class: TopLevelType, ContextProtocol {
         }
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension Class {
+    public init<Context: ReadingContext>(descriptor: ClassDescriptor, in context: Context) throws {
+        self.descriptor = descriptor
+        let genericContext = try descriptor.typeGenericContext(in: context)
+        self.genericContext = genericContext
+        var currentOffset = descriptor.offset + descriptor.layoutSize
+        if let genericContext {
+            currentOffset += genericContext.size
+        }
+        try initialize(descriptor: descriptor, currentOffset: &currentOffset, in: context)
+    }
+
+    private mutating func initialize<Context: ReadingContext>(descriptor: ClassDescriptor, currentOffset: inout Int, in context: Context) throws {
+        if descriptor.hasResilientSuperclass {
+            let resilientSuperclass: ResilientSuperclass = try context.readWrapperElement(at: try context.addressFromOffset(currentOffset))
+            self.resilientSuperclass = resilientSuperclass
+            currentOffset.offset(of: ResilientSuperclass.self)
+        } else {
+            self.resilientSuperclass = nil
+        }
+
+        if descriptor.hasForeignMetadataInitialization {
+            let foreignMetadataInitialization: ForeignMetadataInitialization = try context.readWrapperElement(at: try context.addressFromOffset(currentOffset))
+            self.foreignMetadataInitialization = foreignMetadataInitialization
+            currentOffset.offset(of: ForeignMetadataInitialization.self)
+        } else {
+            self.foreignMetadataInitialization = nil
+        }
+
+        if descriptor.hasSingletonMetadataInitialization {
+            let singletonMetadataInitialization: SingletonMetadataInitialization = try context.readWrapperElement(at: try context.addressFromOffset(currentOffset))
+            self.singletonMetadataInitialization = singletonMetadataInitialization
+            currentOffset.offset(of: SingletonMetadataInitialization.self)
+        } else {
+            self.singletonMetadataInitialization = nil
+        }
+
+        if descriptor.hasVTable {
+            let vTableDescriptorHeader: VTableDescriptorHeader = try context.readWrapperElement(at: try context.addressFromOffset(currentOffset))
+            self.vTableDescriptorHeader = vTableDescriptorHeader
+            currentOffset.offset(of: VTableDescriptorHeader.self)
+            let methodDescriptors: [MethodDescriptor] = try context.readWrapperElements(at: try context.addressFromOffset(currentOffset), numberOfElements: vTableDescriptorHeader.vTableSize.cast())
+            self.methodDescriptors = methodDescriptors
+            currentOffset.offset(of: MethodDescriptor.self, numbersOfElements: vTableDescriptorHeader.vTableSize.cast())
+        } else {
+            self.vTableDescriptorHeader = nil
+            self.methodDescriptors = []
+        }
+
+        if descriptor.hasOverrideTable {
+            let overrideTableHeader: OverrideTableHeader = try context.readWrapperElement(at: try context.addressFromOffset(currentOffset))
+            self.overrideTableHeader = overrideTableHeader
+            currentOffset.offset(of: OverrideTableHeader.self)
+            let methodOverrideDescriptors: [MethodOverrideDescriptor] = try context.readWrapperElements(at: try context.addressFromOffset(currentOffset), numberOfElements: overrideTableHeader.numEntries.cast())
+            self.methodOverrideDescriptors = methodOverrideDescriptors
+            currentOffset.offset(of: MethodOverrideDescriptor.self, numbersOfElements: overrideTableHeader.numEntries.cast())
+        } else {
+            self.overrideTableHeader = nil
+            self.methodOverrideDescriptors = []
+        }
+
+        if descriptor.hasObjCResilientClassStub {
+            let objcResilientClassStubInfo: ObjCResilientClassStubInfo = try context.readWrapperElement(at: try context.addressFromOffset(currentOffset))
+            self.objcResilientClassStubInfo = objcResilientClassStubInfo
+            currentOffset.offset(of: ObjCResilientClassStubInfo.self)
+        } else {
+            self.objcResilientClassStubInfo = nil
+        }
+
+        if descriptor.hasCanonicalMetadataPrespecializations {
+            let count: CanonicalSpecializedMetadatasListCount = try context.readElement(at: try context.addressFromOffset(currentOffset))
+            self.canonicalSpecializedMetadatasListCount = count
+            currentOffset.offset(of: CanonicalSpecializedMetadatasListCount.self)
+            let countValue = count.rawValue
+            let canonicalSpecializedMetadatas: [CanonicalSpecializedMetadatasListEntry] = try context.readWrapperElements(at: try context.addressFromOffset(currentOffset), numberOfElements: countValue.cast())
+            self.canonicalSpecializedMetadatas = canonicalSpecializedMetadatas
+            currentOffset.offset(of: CanonicalSpecializedMetadatasListEntry.self, numbersOfElements: countValue.cast())
+            let canonicalSpecializedMetadataAccessors: [CanonicalSpecializedMetadataAccessorsListEntry] = try context.readWrapperElements(at: try context.addressFromOffset(currentOffset), numberOfElements: countValue.cast())
+            self.canonicalSpecializedMetadataAccessors = canonicalSpecializedMetadataAccessors
+            currentOffset.offset(of: CanonicalSpecializedMetadataAccessorsListEntry.self, numbersOfElements: countValue.cast())
+            let canonicalSpecializedMetadatasCachingOnceToken: CanonicalSpecializedMetadatasCachingOnceToken = try context.readWrapperElement(at: try context.addressFromOffset(currentOffset))
+            self.canonicalSpecializedMetadatasCachingOnceToken = canonicalSpecializedMetadatasCachingOnceToken
+            currentOffset.offset(of: CanonicalSpecializedMetadatasCachingOnceToken.self)
+        } else {
+            self.canonicalSpecializedMetadatasListCount = nil
+            self.canonicalSpecializedMetadatas = []
+            self.canonicalSpecializedMetadataAccessors = []
+            self.canonicalSpecializedMetadatasCachingOnceToken = nil
+        }
+
+        if descriptor.flags.contains(.hasInvertibleProtocols) {
+            let invertibleProtocolSet: InvertibleProtocolSet = try context.readElement(at: try context.addressFromOffset(currentOffset))
+            self.invertibleProtocolSet = invertibleProtocolSet
+            currentOffset.offset(of: InvertibleProtocolSet.self)
+        } else {
+            self.invertibleProtocolSet = nil
+        }
+
+        if descriptor.hasSingletonMetadataPointer {
+            let singletonMetadataPointer: SingletonMetadataPointer = try context.readWrapperElement(at: try context.addressFromOffset(currentOffset))
+            self.singletonMetadataPointer = singletonMetadataPointer
+            currentOffset.offset(of: SingletonMetadataPointer.self)
+        } else {
+            self.singletonMetadataPointer = nil
+        }
+
+        if descriptor.hasDefaultOverrideTable {
+            let methodDefaultOverrideTableHeader: MethodDefaultOverrideTableHeader = try context.readWrapperElement(at: try context.addressFromOffset(currentOffset))
+            self.methodDefaultOverrideTableHeader = methodDefaultOverrideTableHeader
+            currentOffset.offset(of: MethodDefaultOverrideTableHeader.self)
+            let methodDefaultOverrideDescriptors: [MethodDefaultOverrideDescriptor] = try context.readWrapperElements(at: try context.addressFromOffset(currentOffset), numberOfElements: methodDefaultOverrideTableHeader.numEntries.cast())
+            self.methodDefaultOverrideDescriptors = methodDefaultOverrideDescriptors
+            currentOffset.offset(of: MethodDefaultOverrideDescriptor.self, numbersOfElements: methodDefaultOverrideTableHeader.numEntries.cast())
+        } else {
+            self.methodDefaultOverrideTableHeader = nil
+            self.methodDefaultOverrideDescriptors = []
+        }
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Type/Class/ClassDescriptor.swift
+++ b/Sources/MachOSwiftSection/Models/Type/Class/ClassDescriptor.swift
@@ -99,3 +99,15 @@ extension ClassDescriptor {
         return ExtraClassDescriptorFlags(rawValue: layout.metadataPositiveSizeInWordsOrExtraClassFlags).hasObjCResilientClassStub
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension ClassDescriptor {
+    public func resilientMetadataBounds<Context: ReadingContext>(in context: Context) throws -> StoredClassMetadataBounds {
+        return try RelativeDirectPointer<StoredClassMetadataBounds>(relativeOffset: Int32(bitPattern: layout.metadataNegativeSizeInWordsOrResilientMetadataBounds)).resolve(at: try context.addressFromOffset(offset(of: \.metadataNegativeSizeInWordsOrResilientMetadataBounds)), in: context)
+    }
+
+    public func superclassTypeMangledName<Context: ReadingContext>(in context: Context) throws -> MangledName? {
+        try layout.superclassType.resolve(at: try context.addressFromOffset(offset(of: \.superclassType)), in: context)
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Type/Class/Metadata/AnyClassMetadata/AnyClassMetadataProtocol.swift
+++ b/Sources/MachOSwiftSection/Models/Type/Class/Metadata/AnyClassMetadata/AnyClassMetadataProtocol.swift
@@ -8,8 +8,16 @@ extension AnyClassMetadataProtocol {
     public func asFinalClassMetadata<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO) throws -> AnyClassMetadata {
         try .resolve(from: offset, in: machO)
     }
-    
+
     public func asFinalClassMetadata() throws -> AnyClassMetadata {
         try .resolve(from: asPointer)
+    }
+}
+
+// MARK: - ReadingContext Support
+
+extension AnyClassMetadataProtocol {
+    public func asFinalClassMetadata<Context: ReadingContext>(in context: Context) throws -> AnyClassMetadata {
+        try .resolve(at: try context.addressFromOffset(offset), in: context)
     }
 }

--- a/Sources/MachOSwiftSection/Models/Type/Class/Metadata/AnyClassMetadataObjCInterop/AnyClassMetadataObjCInteropProtocol.swift
+++ b/Sources/MachOSwiftSection/Models/Type/Class/Metadata/AnyClassMetadataObjCInterop/AnyClassMetadataObjCInteropProtocol.swift
@@ -31,3 +31,15 @@ extension AnyClassMetadataObjCInteropProtocol {
         layout.data & 2 != 0
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension AnyClassMetadataObjCInteropProtocol {
+    public func asFinalClassMetadata<Context: ReadingContext>(in context: Context) throws -> ClassMetadataObjCInterop {
+        try .resolve(at: try context.addressFromOffset(offset), in: context)
+    }
+
+    public func superclass<Context: ReadingContext>(in context: Context) throws -> AnyClassMetadataObjCInterop? {
+        try layout.superclass.resolve(in: context)
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Type/Class/Metadata/FinalClassMetadataProtocol.swift
+++ b/Sources/MachOSwiftSection/Models/Type/Class/Metadata/FinalClassMetadataProtocol.swift
@@ -22,8 +22,23 @@ extension FinalClassMetadataProtocol where Layout: FinalClassMetadataLayout {
     public func descriptor<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO) throws -> ClassDescriptor? {
         try layout.descriptor.resolve(in: machO)
     }
-    
+
     public func descriptor() throws -> ClassDescriptor? {
         try layout.descriptor.resolve()
+    }
+}
+
+// MARK: - ReadingContext Support
+
+extension FinalClassMetadataProtocol where Layout: FinalClassMetadataLayout {
+    public func fieldOffsets<Context: ReadingContext>(for descriptor: ClassDescriptor? = nil, in context: Context) throws -> [StoredPointer] {
+        guard let descriptor = try descriptor ?? layout.descriptor.resolve(in: context) else { return [] }
+        guard descriptor.fieldOffsetVectorOffset != .zero else { return [] }
+        let fieldOffsetsOffset = offset.offseting(of: StoredPointer.self, numbersOfElements: descriptor.fieldOffsetVectorOffset.cast())
+        return try context.readElements(at: try context.addressFromOffset(fieldOffsetsOffset), numberOfElements: descriptor.numFields.cast())
+    }
+
+    public func descriptor<Context: ReadingContext>(in context: Context) throws -> ClassDescriptor? {
+        try layout.descriptor.resolve(in: context)
     }
 }

--- a/Sources/MachOSwiftSection/Models/Type/Class/Method/MethodDefaultOverrideDescriptor.swift
+++ b/Sources/MachOSwiftSection/Models/Type/Class/Method/MethodDefaultOverrideDescriptor.swift
@@ -25,7 +25,7 @@ extension MethodDefaultOverrideDescriptor {
     }
 
     public func replacementMethodDescriptor<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO) throws -> SymbolOrElement<MethodDescriptor>? {
-        return try layout.replacement.resolve(from: offset(of: \.original), in: machO).asOptional
+        return try layout.replacement.resolve(from: offset(of: \.replacement), in: machO).asOptional
     }
 
     public func implementationSymbols<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO) throws -> Symbols? {
@@ -39,7 +39,7 @@ extension MethodDefaultOverrideDescriptor {
     }
 
     public func replacementMethodDescriptor() throws -> SymbolOrElement<MethodDescriptor>? {
-        return try layout.replacement.resolve(from: pointer(of: \.original)).asOptional
+        return try layout.replacement.resolve(from: pointer(of: \.replacement)).asOptional
     }
 }
 
@@ -51,7 +51,7 @@ extension MethodDefaultOverrideDescriptor {
     }
 
     public func replacementMethodDescriptor<Context: ReadingContext>(in context: Context) throws -> SymbolOrElement<MethodDescriptor>? {
-        return try layout.replacement.resolve(at: try context.addressFromOffset(offset(of: \.original)), in: context).asOptional
+        return try layout.replacement.resolve(at: try context.addressFromOffset(offset(of: \.replacement)), in: context).asOptional
     }
 
     public func implementationSymbols<Context: ReadingContext>(in context: Context) throws -> Symbols? {

--- a/Sources/MachOSwiftSection/Models/Type/Class/Method/MethodDefaultOverrideDescriptor.swift
+++ b/Sources/MachOSwiftSection/Models/Type/Class/Method/MethodDefaultOverrideDescriptor.swift
@@ -42,3 +42,19 @@ extension MethodDefaultOverrideDescriptor {
         return try layout.replacement.resolve(from: pointer(of: \.original)).asOptional
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension MethodDefaultOverrideDescriptor {
+    public func originalMethodDescriptor<Context: ReadingContext>(in context: Context) throws -> SymbolOrElement<MethodDescriptor>? {
+        return try layout.original.resolve(at: try context.addressFromOffset(offset(of: \.original)), in: context).asOptional
+    }
+
+    public func replacementMethodDescriptor<Context: ReadingContext>(in context: Context) throws -> SymbolOrElement<MethodDescriptor>? {
+        return try layout.replacement.resolve(at: try context.addressFromOffset(offset(of: \.original)), in: context).asOptional
+    }
+
+    public func implementationSymbols<Context: ReadingContext>(in context: Context) throws -> Symbols? {
+        return try layout.implementation.resolve(at: try context.addressFromOffset(offset(of: \.implementation)), in: context)
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Type/Class/Method/MethodDescriptor.swift
+++ b/Sources/MachOSwiftSection/Models/Type/Class/Method/MethodDescriptor.swift
@@ -23,3 +23,11 @@ extension MethodDescriptor {
         return try layout.implementation.resolve(from: offset(of: \.implementation), in: machO)
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension MethodDescriptor {
+    public func implementationSymbols<Context: ReadingContext>(in context: Context) throws -> Symbols? {
+        return try layout.implementation.resolve(at: try context.addressFromOffset(offset(of: \.implementation)), in: context)
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Type/Class/Method/MethodOverrideDescriptor.swift
+++ b/Sources/MachOSwiftSection/Models/Type/Class/Method/MethodOverrideDescriptor.swift
@@ -36,3 +36,19 @@ extension MethodOverrideDescriptor {
         return try layout.implementation.resolve(from: offset(of: \.implementation), in: machO)
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension MethodOverrideDescriptor {
+    public func classDescriptor<Context: ReadingContext>(in context: Context) throws -> SymbolOrElement<ContextDescriptorWrapper>? {
+        return try layout.`class`.resolve(at: try context.addressFromOffset(offset(of: \.`class`)), in: context).asOptional
+    }
+
+    public func methodDescriptor<Context: ReadingContext>(in context: Context) throws -> SymbolOrElement<MethodDescriptor>? {
+        return try layout.method.resolve(at: try context.addressFromOffset(offset(of: \.method)), in: context).asOptional
+    }
+
+    public func implementationSymbols<Context: ReadingContext>(in context: Context) throws -> Symbols? {
+        return try layout.implementation.resolve(at: try context.addressFromOffset(offset(of: \.implementation)), in: context)
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Type/Enum/Enum.swift
+++ b/Sources/MachOSwiftSection/Models/Type/Enum/Enum.swift
@@ -99,3 +99,67 @@ public struct Enum: TopLevelType, ContextProtocol {
         }
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension Enum {
+    public init<Context: ReadingContext>(descriptor: EnumDescriptor, in context: Context) throws {
+        self.descriptor = descriptor
+        var currentOffset = descriptor.offset + descriptor.layoutSize
+        let genericContext = try descriptor.typeGenericContext(in: context)
+        if let genericContext {
+            currentOffset += genericContext.size
+        }
+        self.genericContext = genericContext
+        try initialize(descriptor: descriptor, currentOffset: &currentOffset, in: context)
+    }
+
+    private mutating func initialize<Context: ReadingContext>(descriptor: EnumDescriptor, currentOffset: inout Int, in context: Context) throws {
+
+        let typeFlags = try required(descriptor.flags.kindSpecificFlags?.typeFlags)
+
+        if typeFlags.hasForeignMetadataInitialization {
+            self.foreignMetadataInitialization = try context.readWrapperElement(at: try context.addressFromOffset(currentOffset)) as ForeignMetadataInitialization
+            currentOffset.offset(of: ForeignMetadataInitialization.self)
+        } else {
+            self.foreignMetadataInitialization = nil
+        }
+
+        if typeFlags.hasSingletonMetadataInitialization {
+            self.singletonMetadataInitialization = try context.readWrapperElement(at: try context.addressFromOffset(currentOffset)) as SingletonMetadataInitialization
+            currentOffset.offset(of: SingletonMetadataInitialization.self)
+        } else {
+            self.singletonMetadataInitialization = nil
+        }
+
+        if descriptor.hasCanonicalMetadataPrespecializations {
+            let count: CanonicalSpecializedMetadatasListCount = try context.readElement(at: try context.addressFromOffset(currentOffset))
+            currentOffset.offset(of: CanonicalSpecializedMetadatasListCount.self)
+            let countValue = count.rawValue
+            let canonicalMetadataPrespecializations: [CanonicalSpecializedMetadatasListEntry] = try context.readWrapperElements(at: try context.addressFromOffset(currentOffset), numberOfElements: countValue.cast())
+            currentOffset.offset(of: CanonicalSpecializedMetadatasListEntry.self, numbersOfElements: countValue.cast())
+            self.canonicalSpecializedMetadatas = canonicalMetadataPrespecializations
+            self.canonicalSpecializedMetadatasListCount = count
+            self.canonicalSpecializedMetadatasCachingOnceToken = try context.readWrapperElement(at: try context.addressFromOffset(currentOffset)) as CanonicalSpecializedMetadatasCachingOnceToken
+            currentOffset.offset(of: CanonicalSpecializedMetadatasCachingOnceToken.self)
+        } else {
+            self.canonicalSpecializedMetadatas = []
+            self.canonicalSpecializedMetadatasListCount = nil
+            self.canonicalSpecializedMetadatasCachingOnceToken = nil
+        }
+
+        if descriptor.flags.hasInvertibleProtocols {
+            self.invertibleProtocolSet = try context.readElement(at: try context.addressFromOffset(currentOffset)) as InvertibleProtocolSet
+            currentOffset.offset(of: InvertibleProtocolSet.self)
+        } else {
+            self.invertibleProtocolSet = nil
+        }
+
+        if descriptor.hasSingletonMetadataPointer {
+            self.singletonMetadataPointer = try context.readWrapperElement(at: try context.addressFromOffset(currentOffset)) as SingletonMetadataPointer
+            currentOffset.offset(of: SingletonMetadataPointer.self)
+        } else {
+            self.singletonMetadataPointer = nil
+        }
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Type/Enum/Metadata/EnumMetadataProtocol.swift
+++ b/Sources/MachOSwiftSection/Models/Type/Enum/Metadata/EnumMetadataProtocol.swift
@@ -35,7 +35,7 @@ extension EnumMetadataProtocol {
 
 extension EnumMetadataProtocol {
     public func enumDescriptor<Context: ReadingContext>(in context: Context) throws -> EnumDescriptor {
-        try layout.descriptor.resolve(in: context).enum!
+        try descriptor(in: context).enum!
     }
 
     public func payloadSize<Context: ReadingContext>(descriptor: EnumDescriptor? = nil, in context: Context) throws -> StoredSize? {

--- a/Sources/MachOSwiftSection/Models/Type/Enum/Metadata/EnumMetadataProtocol.swift
+++ b/Sources/MachOSwiftSection/Models/Type/Enum/Metadata/EnumMetadataProtocol.swift
@@ -30,3 +30,20 @@ extension EnumMetadataProtocol {
         return try asPointer.readElement(offset: offset)
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension EnumMetadataProtocol {
+    public func enumDescriptor<Context: ReadingContext>(in context: Context) throws -> EnumDescriptor {
+        try layout.descriptor.resolve(in: context).enum!
+    }
+
+    public func payloadSize<Context: ReadingContext>(descriptor: EnumDescriptor? = nil, in context: Context) throws -> StoredSize? {
+        let descriptor = try descriptor ?? enumDescriptor(in: context)
+        guard descriptor.hasPayloadSizeOffset else {
+            return nil
+        }
+        let offset = offset.offseting(of: StoredSize.self, numbersOfElements: descriptor.payloadSizeOffset)
+        return try context.readElement(at: try context.addressFromOffset(offset))
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Type/Enum/MultiPayloadEnumDescriptor.swift
+++ b/Sources/MachOSwiftSection/Models/Type/Enum/MultiPayloadEnumDescriptor.swift
@@ -115,3 +115,36 @@ extension MultiPayloadEnumDescriptor: TopLevelDescriptor {
         MemoryLayout<RelativeDirectPointer<String>>.size + (contentsSizeInWord.cast() * MemoryLayout<UInt32>.size)
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension MultiPayloadEnumDescriptor {
+    public func mangledTypeName<Context: ReadingContext>(in context: Context) throws -> MangledName {
+        return try layout.mangledTypeName.resolve(at: try context.addressFromOffset(offset), in: context)
+    }
+
+    public func contents<Context: ReadingContext>(in context: Context) throws -> [UInt32] {
+        return try context.readElements(at: try context.addressFromOffset(offset(of: \.sizeFlags)), numberOfElements: contentsSizeInWord.cast())
+    }
+
+    public func payloadSpareBits<Context: ReadingContext>(in context: Context) throws -> [UInt8] {
+        guard usesPayloadSpareBits else { return [] }
+        return try context.readElements(at: try context.addressFromOffset(offset + MemoryLayout<RelativeOffset>.size + MemoryLayout<UInt32>.size * payloadSpareBitsIndex), numberOfElements: payloadSpareBitMaskByteCount(in: context).cast())
+    }
+
+    public func payloadSpareBitMaskByteOffset<Context: ReadingContext>(in context: Context) throws -> UInt32 {
+        if usesPayloadSpareBits {
+            return try contents(in: context)[payloadSpareBitMaskByteCountIndex] >> 16
+        } else {
+            return 0
+        }
+    }
+
+    public func payloadSpareBitMaskByteCount<Context: ReadingContext>(in context: Context) throws -> UInt32 {
+        if usesPayloadSpareBits {
+            return try contents(in: context)[payloadSpareBitMaskByteCountIndex] & 0xFFFF
+        } else {
+            return 0
+        }
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Type/Struct/Struct.swift
+++ b/Sources/MachOSwiftSection/Models/Type/Struct/Struct.swift
@@ -93,3 +93,71 @@ public struct Struct: TopLevelType, ContextProtocol {
         }
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension Struct {
+    public init<Context: ReadingContext>(descriptor: StructDescriptor, in context: Context) throws {
+        self.descriptor = descriptor
+
+        var currentOffset = descriptor.offset + descriptor.layoutSize
+
+        let genericContext = try descriptor.typeGenericContext(in: context)
+
+        if let genericContext {
+            currentOffset += genericContext.size
+        }
+
+        self.genericContext = genericContext
+
+        try initialize(descriptor: descriptor, currentOffset: &currentOffset, in: context)
+    }
+
+    private mutating func initialize<Context: ReadingContext>(descriptor: StructDescriptor, currentOffset: inout Int, in context: Context) throws {
+        let typeFlags = try required(descriptor.flags.kindSpecificFlags?.typeFlags)
+
+        if typeFlags.hasForeignMetadataInitialization {
+            foreignMetadataInitialization = try context.readWrapperElement(at: try context.addressFromOffset(currentOffset)) as ForeignMetadataInitialization
+            currentOffset.offset(of: ForeignMetadataInitialization.self)
+        } else {
+            foreignMetadataInitialization = nil
+        }
+
+        if typeFlags.hasSingletonMetadataInitialization {
+            singletonMetadataInitialization = try context.readWrapperElement(at: try context.addressFromOffset(currentOffset)) as SingletonMetadataInitialization
+            currentOffset.offset(of: SingletonMetadataInitialization.self)
+        } else {
+            singletonMetadataInitialization = nil
+        }
+
+        if descriptor.hasCanonicalMetadataPrespecializations {
+            let count: CanonicalSpecializedMetadatasListCount = try context.readElement(at: try context.addressFromOffset(currentOffset))
+            currentOffset.offset(of: CanonicalSpecializedMetadatasListCount.self)
+            let countValue = count.rawValue
+            let canonicalMetadataPrespecializations: [CanonicalSpecializedMetadatasListEntry] = try context.readWrapperElements(at: try context.addressFromOffset(currentOffset), numberOfElements: countValue.cast())
+            currentOffset.offset(of: CanonicalSpecializedMetadatasListEntry.self, numbersOfElements: countValue.cast())
+            canonicalSpecializedMetadatas = canonicalMetadataPrespecializations
+            canonicalSpecializedMetadatasListCount = count
+            canonicalSpecializedMetadatasCachingOnceToken = try context.readWrapperElement(at: try context.addressFromOffset(currentOffset)) as CanonicalSpecializedMetadatasCachingOnceToken
+            currentOffset.offset(of: CanonicalSpecializedMetadatasCachingOnceToken.self)
+        } else {
+            canonicalSpecializedMetadatas = []
+            canonicalSpecializedMetadatasListCount = nil
+            canonicalSpecializedMetadatasCachingOnceToken = nil
+        }
+
+        if descriptor.flags.hasInvertibleProtocols {
+            invertibleProtocolSet = try context.readElement(at: try context.addressFromOffset(currentOffset)) as InvertibleProtocolSet
+            currentOffset.offset(of: InvertibleProtocolSet.self)
+        } else {
+            invertibleProtocolSet = nil
+        }
+
+        if descriptor.hasSingletonMetadataPointer {
+            singletonMetadataPointer = try context.readWrapperElement(at: try context.addressFromOffset(currentOffset)) as SingletonMetadataPointer
+            currentOffset.offset(of: SingletonMetadataPointer.self)
+        } else {
+            singletonMetadataPointer = nil
+        }
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Type/Struct/StructMetadataProtocol.swift
+++ b/Sources/MachOSwiftSection/Models/Type/Struct/StructMetadataProtocol.swift
@@ -28,3 +28,19 @@ extension StructMetadataProtocol {
         return try asPointer.advanced(by: descriptor.fieldOffsetVector.cast() * MemoryLayout<StoredSize>.size).readElements(numberOfElements: descriptor.numFields.cast())
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension StructMetadataProtocol {
+    public func structDescriptor<Context: ReadingContext>(in context: Context) throws -> StructDescriptor {
+        try layout.descriptor.resolve(in: context).struct!
+    }
+
+    public func fieldOffsets<Context: ReadingContext>(for descriptor: StructDescriptor? = nil, in context: Context) throws -> [UInt32] {
+        let descriptor = try descriptor ?? structDescriptor(in: context)
+        guard descriptor.fieldOffsetVector != .zero else { return [] }
+        // Metadata.offset + fieldOffset (eg. 2 * 8)
+        let offset = offset + (descriptor.fieldOffsetVector.cast() * MemoryLayout<StoredSize>.size)
+        return try context.readElements(at: try context.addressFromOffset(offset), numberOfElements: descriptor.numFields.cast())
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Type/Struct/StructMetadataProtocol.swift
+++ b/Sources/MachOSwiftSection/Models/Type/Struct/StructMetadataProtocol.swift
@@ -33,7 +33,7 @@ extension StructMetadataProtocol {
 
 extension StructMetadataProtocol {
     public func structDescriptor<Context: ReadingContext>(in context: Context) throws -> StructDescriptor {
-        try layout.descriptor.resolve(in: context).struct!
+        try descriptor(in: context).struct!
     }
 
     public func fieldOffsets<Context: ReadingContext>(for descriptor: StructDescriptor? = nil, in context: Context) throws -> [UInt32] {

--- a/Sources/MachOSwiftSection/Models/Type/TypeContextDescriptor.swift
+++ b/Sources/MachOSwiftSection/Models/Type/TypeContextDescriptor.swift
@@ -54,3 +54,22 @@ extension TypeContextDescriptor {
         return try asPointer.readWrapperElement() as ClassDescriptor
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension TypeContextDescriptor {
+    public func enumDescriptor<Context: ReadingContext>(in context: Context) throws -> EnumDescriptor? {
+        guard layout.flags.kind == .enum else { return nil }
+        return try context.readWrapperElement(at: try context.addressFromOffset(offset)) as EnumDescriptor
+    }
+
+    public func structDescriptor<Context: ReadingContext>(in context: Context) throws -> StructDescriptor? {
+        guard layout.flags.kind == .struct else { return nil }
+        return try context.readWrapperElement(at: try context.addressFromOffset(offset)) as StructDescriptor
+    }
+
+    public func classDescriptor<Context: ReadingContext>(in context: Context) throws -> ClassDescriptor? {
+        guard layout.flags.kind == .class else { return nil }
+        return try context.readWrapperElement(at: try context.addressFromOffset(offset)) as ClassDescriptor
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Type/TypeContextDescriptorProtocol.swift
+++ b/Sources/MachOSwiftSection/Models/Type/TypeContextDescriptorProtocol.swift
@@ -58,6 +58,18 @@ extension TypeContextDescriptorProtocol {
         guard layout.flags.isGeneric else { return nil }
         return try .init(contextDescriptor: self, in: context)
     }
+
+    public func fieldDescriptor<Context: ReadingContext>(in context: Context) throws -> FieldDescriptor {
+        let address = try context.addressFromOffset(offset + layout.offset(of: .fieldDescriptor))
+        return try layout.fieldDescriptor.resolve(at: address, in: context)
+    }
+
+    public func metadataAccessorFunction<Context: ReadingContext>(in context: Context) throws -> MetadataAccessorFunction? {
+        let fieldAddress = try context.addressFromOffset(offset + layout.offset(of: .accessFunctionPtr))
+        let relativeOffset: Int32 = try context.readElement(at: fieldAddress)
+        let targetAddress = context.advanceAddress(fieldAddress, by: Int(relativeOffset))
+        return try context.runtimePointer(at: targetAddress).map { MetadataAccessorFunction(ptr: $0) }
+    }
 }
 
 extension TypeContextDescriptorProtocol {

--- a/Sources/MachOSwiftSection/Models/Type/TypeContextWrapper.swift
+++ b/Sources/MachOSwiftSection/Models/Type/TypeContextWrapper.swift
@@ -58,3 +58,18 @@ public enum TypeContextWrapper: Sendable {
         }
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension TypeContextWrapper {
+    public static func forTypeContextDescriptorWrapper<Context: ReadingContext>(_ typeContextDescriptorWrapper: TypeContextDescriptorWrapper, in context: Context) throws -> Self {
+        switch typeContextDescriptorWrapper {
+        case .enum(let enumDescriptor):
+            try .enum(.init(descriptor: enumDescriptor, in: context))
+        case .struct(let structDescriptor):
+            try .struct(.init(descriptor: structDescriptor, in: context))
+        case .class(let classDescriptor):
+            try .class(.init(descriptor: classDescriptor, in: context))
+        }
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Type/TypeContextWrapper.swift
+++ b/Sources/MachOSwiftSection/Models/Type/TypeContextWrapper.swift
@@ -17,11 +17,11 @@ public enum TypeContextWrapper: Sendable {
     public var typeContextDescriptorWrapper: TypeContextDescriptorWrapper {
         switch self {
         case .enum(let `enum`):
-            .enum(`enum`.descriptor)
+            return .enum(`enum`.descriptor)
         case .struct(let `struct`):
-            .struct(`struct`.descriptor)
+            return .struct(`struct`.descriptor)
         case .class(let `class`):
-            .class(`class`.descriptor)
+            return .class(`class`.descriptor)
         }
     }
     
@@ -39,22 +39,22 @@ public enum TypeContextWrapper: Sendable {
     public static func forTypeContextDescriptorWrapper(_ typeContextDescriptorWrapper: TypeContextDescriptorWrapper) throws -> Self {
         switch typeContextDescriptorWrapper {
         case .enum(let enumDescriptor):
-            try .enum(.init(descriptor: enumDescriptor))
+            return try .enum(.init(descriptor: enumDescriptor))
         case .struct(let structDescriptor):
-            try .struct(.init(descriptor: structDescriptor))
+            return try .struct(.init(descriptor: structDescriptor))
         case .class(let classDescriptor):
-            try .class(.init(descriptor: classDescriptor))
+            return try .class(.init(descriptor: classDescriptor))
         }
     }
 
     public static func forTypeContextDescriptorWrapper(_ typeContextDescriptorWrapper: TypeContextDescriptorWrapper, in machO: some MachOSwiftSectionRepresentableWithCache) throws -> Self {
         switch typeContextDescriptorWrapper {
         case .enum(let enumDescriptor):
-            try .enum(.init(descriptor: enumDescriptor, in: machO))
+            return try .enum(.init(descriptor: enumDescriptor, in: machO))
         case .struct(let structDescriptor):
-            try .struct(.init(descriptor: structDescriptor, in: machO))
+            return try .struct(.init(descriptor: structDescriptor, in: machO))
         case .class(let classDescriptor):
-            try .class(.init(descriptor: classDescriptor, in: machO))
+            return try .class(.init(descriptor: classDescriptor, in: machO))
         }
     }
 }
@@ -65,11 +65,11 @@ extension TypeContextWrapper {
     public static func forTypeContextDescriptorWrapper<Context: ReadingContext>(_ typeContextDescriptorWrapper: TypeContextDescriptorWrapper, in context: Context) throws -> Self {
         switch typeContextDescriptorWrapper {
         case .enum(let enumDescriptor):
-            try .enum(.init(descriptor: enumDescriptor, in: context))
+            return try .enum(.init(descriptor: enumDescriptor, in: context))
         case .struct(let structDescriptor):
-            try .struct(.init(descriptor: structDescriptor, in: context))
+            return try .struct(.init(descriptor: structDescriptor, in: context))
         case .class(let classDescriptor):
-            try .class(.init(descriptor: classDescriptor, in: context))
+            return try .class(.init(descriptor: classDescriptor, in: context))
         }
     }
 }

--- a/Sources/MachOSwiftSection/Models/Type/TypeReference.swift
+++ b/Sources/MachOSwiftSection/Models/Type/TypeReference.swift
@@ -53,3 +53,20 @@ public enum ResolvedTypeReference: Sendable {
     case directObjCClassName(String?)
     case indirectObjCClass(SymbolOrElement<ClassMetadataObjCInterop>?)
 }
+
+// MARK: - ReadingContext Support
+
+extension TypeReference {
+    public func resolve<Context: ReadingContext>(at offset: Int, in context: Context) throws -> ResolvedTypeReference {
+        switch self {
+        case .directTypeDescriptor(let relativeDirectPointer):
+            return try .directTypeDescriptor(relativeDirectPointer.resolve(at: try context.addressFromOffset(offset), in: context))
+        case .indirectTypeDescriptor(let relativeIndirectPointer):
+            return try .indirectTypeDescriptor(relativeIndirectPointer.resolve(at: try context.addressFromOffset(offset), in: context).resolve(in: context).asOptional)
+        case .directObjCClassName(let relativeDirectPointer):
+            return try .directObjCClassName(relativeDirectPointer.resolve(at: try context.addressFromOffset(offset), in: context))
+        case .indirectObjCClass(let relativeIndirectPointer):
+            return try .indirectObjCClass(relativeIndirectPointer.resolve(at: try context.addressFromOffset(offset), in: context).resolve(in: context).asOptional)
+        }
+    }
+}

--- a/Sources/MachOSwiftSection/Models/Type/ValueMetadataProtocol.swift
+++ b/Sources/MachOSwiftSection/Models/Type/ValueMetadataProtocol.swift
@@ -12,3 +12,11 @@ extension ValueMetadataProtocol {
         try layout.descriptor.resolve()
     }
 }
+
+// MARK: - ReadingContext Support
+
+extension ValueMetadataProtocol {
+    public func descriptor<Context: ReadingContext>(in context: Context) throws -> ValueTypeDescriptorWrapper {
+        try layout.descriptor.resolve(in: context)
+    }
+}

--- a/Sources/MachOSwiftSection/Utils/MachOSwiftSectionError.swift
+++ b/Sources/MachOSwiftSection/Utils/MachOSwiftSectionError.swift
@@ -5,6 +5,7 @@ import MachOFoundation
 public enum MachOSwiftSectionError: LocalizedError, Sendable {
     case sectionNotFound(section: MachOSwiftSectionName, allSectionNames: [String])
     case invalidSectionAlignment(section: MachOSwiftSectionName, align: Int)
+    case unknownMetadataKind(rawValue: UInt)
 
     public var errorDescription: String? {
         switch self {
@@ -12,6 +13,8 @@ public enum MachOSwiftSectionError: LocalizedError, Sendable {
             return "Swift section \(section.rawValue) not found in Mach-O. Available sections: \(allSectionNames.joined(separator: ", "))"
         case .invalidSectionAlignment(let section, let align):
             return "Invalid alignment for Swift section \(section.rawValue). Expected alignment is 4, but found \(align)."
+        case .unknownMetadataKind(let rawValue):
+            return "Unknown metadata kind: 0x\(String(rawValue, radix: 16)). MetadataWrapper cannot resolve metadata of an unrecognized kind."
         }
     }
 }

--- a/Sources/MachOTestingSupport/SnapshotDumpableTests.swift
+++ b/Sources/MachOTestingSupport/SnapshotDumpableTests.swift
@@ -395,7 +395,7 @@ extension SnapshotDumpableTests {
             } catch {
                 continue
             }
-            let moduleName = (try? protocolDescriptor.moduleContextDesciptor(in: machO)?.name(in: machO)) ?? ""
+            let moduleName = (try? protocolDescriptor.moduleContextDescriptor(in: machO)?.name(in: machO)) ?? ""
             let key = "\(moduleName).\(name)"
             // First writer wins; this produces stable behavior if duplicates exist.
             if lookup[key] == nil {

--- a/docs/superpowers/plans/2026-05-02-reading-context-api.md
+++ b/docs/superpowers/plans/2026-05-02-reading-context-api.md
@@ -1,0 +1,751 @@
+# ReadingContext API Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `ReadingContext`-based overloads to every method in `Sources/MachOSwiftSection/Models/` that currently exposes only the MachO/InProcess API pair, plus the small `runtimePointer(at:)` extension needed to express runtime-pointer-returning methods.
+
+**Architecture:** Mechanical mirroring per the substitution table in the design doc. New overloads sit in `// MARK: - ReadingContext Support` sections. Existing MachO/InProcess code is left untouched. One small protocol extension (`runtimePointer(at:)`) is added to `MachOReading` to support `metadataAccessorFunction`.
+
+**Tech Stack:** Swift 6.2+ / Xcode 26.0+, Swift Package Manager. Build via `swift build`, test via `swift test`. Reference doc: `docs/superpowers/specs/2026-05-02-reading-context-api-design.md`.
+
+---
+
+## Working agreements (apply to every task)
+
+These are rules the implementer follows for every batch — the per-task steps below assume these:
+
+- **Reuse the per-method pattern** documented in the design doc, section "Pattern for the common case". The substitution table is the contract; do not invent a new style.
+- **Place new overloads in a dedicated `// MARK: - ReadingContext Support` extension** at the bottom of the file. If the file already has one, append to it.
+- **Do not modify existing MachO or InProcess code** in any task except Task 1.
+- **Mirror the MachO overload exactly:** same return type, same nullability, same `throws`, same parent helpers (e.g. `try someMethod(in: context)` instead of `try someMethod(in: machO)`).
+- **Local offset arithmetic on `Int`** (`currentOffset.offset(of:)`, `currentOffset.align(to:)`, `currentOffset += ...`) stays untouched. Only the *read site* uses `try context.addressFromOffset(currentOffset)`.
+- **For partial files** (already have some `<Context: ReadingContext>` methods), add only the methods that are *missing* relative to the file's MachO API surface. Do not duplicate existing ReadingContext methods.
+- **Build after every batch:** `swift package update && swift build 2>&1 | xcsift`. Must succeed before commit.
+- **Commit message convention:** `feat(MachOSwiftSection): add ReadingContext API for <area>` for content batches; `feat(MachOReading): add runtimePointer extension` for Task 1.
+- **One commit per batch.** Do not stack multiple batches in one commit.
+
+---
+
+## Task 1: Add `runtimePointer(at:)` extension to `MachOReading`
+
+**Files:**
+- Modify: `Sources/MachOReading/ReadingContext/ReadingContext.swift` (append extension at bottom)
+- Modify: `Sources/MachOReading/ReadingContext/MachOContext.swift` (append extension)
+- Modify: `Sources/MachOReading/ReadingContext/InProcessContext.swift` (append extension)
+
+- [ ] **Step 1: Read the three target files end-to-end**
+
+Read all three files completely so the extension placement matches existing style (imports, doc comment style, ordering).
+
+```bash
+# verify imports — MachOContext already imports MachOKit, so MachOImage is in scope
+grep -n "import" Sources/MachOReading/ReadingContext/MachOContext.swift
+```
+
+- [ ] **Step 2: Append default extension to `ReadingContext.swift`**
+
+After the existing `extension ReadingContext { ... bindRebaseResolver default ... }` block, add:
+
+```swift
+extension ReadingContext {
+    /// Converts a context-specific address to a runtime `UnsafeRawPointer`,
+    /// when this context is mapped into the current process.
+    ///
+    /// - `InProcessContext`: returns the address itself (already a pointer).
+    /// - `MachOContext<MachOImage>`: returns `machO.ptr + address`.
+    /// - `MachOContext<MachOFile>` / other readers: returns `nil`.
+    ///
+    /// This is an extension method (not a protocol requirement) so adding
+    /// new `ReadingContext` conformers does not become a breaking change.
+    /// Concrete contexts that *can* vend a runtime pointer override this in
+    /// their own files.
+    public func runtimePointer(at address: Address) throws -> UnsafeRawPointer? {
+        nil
+    }
+}
+```
+
+- [ ] **Step 3: Append override to `MachOContext.swift`**
+
+At the bottom of the file (after the `Convenience Extensions` MARK):
+
+```swift
+// MARK: - Runtime Pointer Support
+
+extension MachOContext {
+    /// Returns the runtime pointer for the given file offset when the
+    /// underlying reader is a `MachOImage` mapped into the current process.
+    /// Returns `nil` for `MachOFile` and other non-resident readers.
+    public func runtimePointer(at address: Int) throws -> UnsafeRawPointer? {
+        if let machOImage = machO as? MachOImage {
+            return machOImage.ptr + UnsafeRawPointer.Stride(address)
+        }
+        return nil
+    }
+}
+```
+
+- [ ] **Step 4: Append override to `InProcessContext.swift`**
+
+At the bottom of the file:
+
+```swift
+// MARK: - Runtime Pointer Support
+
+extension InProcessContext {
+    /// In-process addresses are already runtime pointers, so this returns
+    /// the address unchanged.
+    public func runtimePointer(at address: UnsafeRawPointer) throws -> UnsafeRawPointer? {
+        address
+    }
+}
+```
+
+- [ ] **Step 5: Build**
+
+```bash
+swift package update && swift build 2>&1 | xcsift
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/MachOReading/ReadingContext/ReadingContext.swift \
+        Sources/MachOReading/ReadingContext/MachOContext.swift \
+        Sources/MachOReading/ReadingContext/InProcessContext.swift
+git commit -m "feat(MachOReading): add runtimePointer extension for ReadingContext
+
+Default returns nil. MachOContext returns machO.ptr + address when the
+underlying reader is a MachOImage; InProcessContext returns the address
+itself. Enables runtime-pointer-returning methods (e.g.
+metadataAccessorFunction) to be expressed under the unified ReadingContext
+abstraction without per-call type dispatch."
+```
+
+---
+
+## Task 2: `Anonymous/`, `Module/`, `Extension/` (top-level Context wrappers)
+
+**Files:**
+- Modify: `Sources/MachOSwiftSection/Models/Anonymous/AnonymousContext.swift`
+- Modify: `Sources/MachOSwiftSection/Models/Module/ModuleContext.swift`
+- Modify: `Sources/MachOSwiftSection/Models/Extension/ExtensionContext.swift`
+
+These three files each have a MachO `init(descriptor:in:)` and an InProcess `init(descriptor:)`. Add a third `init(descriptor:in:Context)` mirroring the MachO version.
+
+- [ ] **Step 1: Add `init(descriptor:in:Context)` to `AnonymousContext.swift`**
+
+Append at bottom:
+
+```swift
+extension AnonymousContext {
+    public init<Context: ReadingContext>(descriptor: AnonymousContextDescriptor, in context: Context) throws {
+        self.descriptor = descriptor
+        var currentOffset = descriptor.offset + descriptor.layoutSize
+
+        let genericContext = try descriptor.genericContext(in: context)
+        if let genericContext {
+            currentOffset += genericContext.size
+        }
+        self.genericContext = genericContext
+
+        if descriptor.hasMangledName {
+            let mangledNamePointerAddress = try context.addressFromOffset(currentOffset)
+            let mangledNamePointer: RelativeDirectPointer<MangledName> = try context.readElement(at: mangledNamePointerAddress)
+            self.mangledName = try mangledNamePointer.resolve(at: mangledNamePointerAddress, in: context)
+            currentOffset += MemoryLayout<RelativeDirectPointer<MangledName>>.size
+        } else {
+            self.mangledName = nil
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add `init(descriptor:in:Context)` to `ModuleContext.swift`**
+
+Append at bottom:
+
+```swift
+extension ModuleContext {
+    public init<Context: ReadingContext>(descriptor: ModuleContextDescriptor, in context: Context) throws {
+        self.descriptor = descriptor
+        self.name = try descriptor.name(in: context)
+    }
+}
+```
+
+(`name(in: Context)` already exists on `NamedContextDescriptorProtocol`.)
+
+- [ ] **Step 3: Add `init(descriptor:in:Context)` to `ExtensionContext.swift`**
+
+Append at bottom:
+
+```swift
+extension ExtensionContext {
+    public init<Context: ReadingContext>(descriptor: ExtensionContextDescriptor, in context: Context) throws {
+        self.descriptor = descriptor
+        self.extendedContextMangledName = try descriptor.extendedContext(in: context)
+        self.genericContext = try descriptor.genericContext(in: context)
+    }
+}
+```
+
+If `extendedContext(in: Context)` does not yet exist on `ExtensionContextDescriptor`, add it first inside `Sources/MachOSwiftSection/Models/Extension/ExtensionContextDescriptor.swift` mirroring the MachO version, then complete this step.
+
+- [ ] **Step 4: Build**
+
+```bash
+swift build 2>&1 | xcsift
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/MachOSwiftSection/Models/Anonymous/AnonymousContext.swift \
+        Sources/MachOSwiftSection/Models/Module/ModuleContext.swift \
+        Sources/MachOSwiftSection/Models/Extension/ExtensionContext.swift \
+        Sources/MachOSwiftSection/Models/Extension/ExtensionContextDescriptor.swift
+git commit -m "feat(MachOSwiftSection): add ReadingContext API for top-level contexts
+
+Mirror the MachO init(descriptor:in:) overloads on AnonymousContext,
+ModuleContext, and ExtensionContext under the ReadingContext abstraction."
+```
+
+---
+
+## Task 3: `ContextDescriptor/` (`ContextProtocol.swift`, `ContextWrapper.swift`)
+
+**Files:**
+- Modify: `Sources/MachOSwiftSection/Models/ContextDescriptor/ContextProtocol.swift`
+- Modify: `Sources/MachOSwiftSection/Models/ContextDescriptor/ContextWrapper.swift`
+
+`ContextProtocol` exposes `parent(in: machO)`. `ContextWrapper` exposes `parent(in: machO)` and `forContextDescriptorWrapper(_:in:)`. Mirror both.
+
+- [ ] **Step 1: Add ReadingContext extension to `ContextProtocol.swift`**
+
+Append at bottom:
+
+```swift
+// MARK: - ReadingContext Support
+
+extension ContextProtocol {
+    public func parent<Context: ReadingContext>(in context: Context) throws -> SymbolOrElement<ContextWrapper>? {
+        try descriptor.parent(in: context)?.map { try ContextWrapper.forContextDescriptorWrapper($0, in: context) }
+    }
+}
+```
+
+- [ ] **Step 2: Add ReadingContext methods to `ContextWrapper.swift`**
+
+Append at bottom (after the existing `parent()` method):
+
+```swift
+// MARK: - ReadingContext Support
+
+extension ContextWrapper {
+    public static func forContextDescriptorWrapper<Context: ReadingContext>(_ contextDescriptorWrapper: ContextDescriptorWrapper, in context: Context) throws -> Self {
+        switch contextDescriptorWrapper {
+        case .type(let typeContextDescriptorWrapper):
+            switch typeContextDescriptorWrapper {
+            case .enum(let enumDescriptor):
+                return try .type(.enum(.init(descriptor: enumDescriptor, in: context)))
+            case .struct(let structDescriptor):
+                return try .type(.struct(.init(descriptor: structDescriptor, in: context)))
+            case .class(let classDescriptor):
+                return try .type(.class(.init(descriptor: classDescriptor, in: context)))
+            }
+        case .protocol(let protocolDescriptor):
+            return try .protocol(.init(descriptor: protocolDescriptor, in: context))
+        case .anonymous(let anonymousContextDescriptor):
+            return try .anonymous(.init(descriptor: anonymousContextDescriptor, in: context))
+        case .extension(let extensionContextDescriptor):
+            return try .extension(.init(descriptor: extensionContextDescriptor, in: context))
+        case .module(let moduleContextDescriptor):
+            return try .module(.init(descriptor: moduleContextDescriptor, in: context))
+        case .opaqueType(let opaqueTypeDescriptor):
+            return try .opaqueType(.init(descriptor: opaqueTypeDescriptor, in: context))
+        }
+    }
+
+    public func parent<Context: ReadingContext>(in context: Context) throws -> SymbolOrElement<ContextWrapper>? {
+        switch self {
+        case .type(let typeWrapper):
+            switch typeWrapper {
+            case .enum(let `enum`):
+                return try `enum`.descriptor.parent(in: context)?.map { try ContextWrapper.forContextDescriptorWrapper($0, in: context) }
+            case .struct(let `struct`):
+                return try `struct`.descriptor.parent(in: context)?.map { try ContextWrapper.forContextDescriptorWrapper($0, in: context) }
+            case .class(let `class`):
+                return try `class`.descriptor.parent(in: context)?.map { try ContextWrapper.forContextDescriptorWrapper($0, in: context) }
+            }
+        case .protocol(let `protocol`):
+            return try `protocol`.descriptor.parent(in: context)?.map { try ContextWrapper.forContextDescriptorWrapper($0, in: context) }
+        case .anonymous(let anonymousContext):
+            return try anonymousContext.descriptor.parent(in: context)?.map { try ContextWrapper.forContextDescriptorWrapper($0, in: context) }
+        case .extension(let extensionContext):
+            return try extensionContext.descriptor.parent(in: context)?.map { try ContextWrapper.forContextDescriptorWrapper($0, in: context) }
+        case .module(let moduleContext):
+            return try moduleContext.descriptor.parent(in: context)?.map { try ContextWrapper.forContextDescriptorWrapper($0, in: context) }
+        case .opaqueType(let opaqueType):
+            return try opaqueType.descriptor.parent(in: context)?.map { try ContextWrapper.forContextDescriptorWrapper($0, in: context) }
+        }
+    }
+}
+```
+
+`ContextWrapper.forContextDescriptorWrapper(_:in:Context)` depends on every concrete Context type having a `init(descriptor:in:Context)` overload. Tasks 2, 4, 5, 6, 7 add those; this task can compile only after they all land — **so move this task's commit to be the last commit in the series** (after Task 7), or split into two: stub today, fill in once the dependents land.
+
+**Recommended:** Land *only* the `parent(in:context:)` portion now (which depends on `descriptor.parent(in:context:)` already provided by `ContextDescriptorProtocol`), and defer `forContextDescriptorWrapper(_:in:context:)` to a later task (Task 11) once all `init(descriptor:in:context:)` overloads exist.
+
+- [ ] **Step 3: Build**
+
+```bash
+swift build 2>&1 | xcsift
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/MachOSwiftSection/Models/ContextDescriptor/ContextProtocol.swift \
+        Sources/MachOSwiftSection/Models/ContextDescriptor/ContextWrapper.swift
+git commit -m "feat(MachOSwiftSection): add ReadingContext API for ContextProtocol/ContextWrapper
+
+Adds parent(in:context:) on both. forContextDescriptorWrapper(_:in:context:)
+is deferred until concrete Context types have their ReadingContext init
+overloads (Task 11)."
+```
+
+---
+
+## Task 4: `Type/Class/` (descriptor + class type + class metadata protocols + method descriptors)
+
+**Files:**
+- Modify: `Sources/MachOSwiftSection/Models/Type/Class/Class.swift`
+- Modify: `Sources/MachOSwiftSection/Models/Type/Class/ClassDescriptor.swift`
+- Modify: `Sources/MachOSwiftSection/Models/Type/Class/Metadata/AnyClassMetadata/AnyClassMetadataProtocol.swift`
+- Modify: `Sources/MachOSwiftSection/Models/Type/Class/Metadata/AnyClassMetadataObjCInterop/AnyClassMetadataObjCInteropProtocol.swift`
+- Modify: `Sources/MachOSwiftSection/Models/Type/Class/Metadata/FinalClassMetadataProtocol.swift`
+- Modify: `Sources/MachOSwiftSection/Models/Type/Class/Method/MethodDescriptor.swift`
+- Modify: `Sources/MachOSwiftSection/Models/Type/Class/Method/MethodOverrideDescriptor.swift`
+- Modify: `Sources/MachOSwiftSection/Models/Type/Class/Method/MethodDefaultOverrideDescriptor.swift`
+
+- [ ] **Step 1: Read each file end-to-end**
+
+For each of the 8 files, list every method with a `<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO)` signature. Those are the methods that need a sibling `<Context: ReadingContext>(in context: Context)` overload.
+
+- [ ] **Step 2: Add ReadingContext overloads to each file**
+
+Apply the substitution table from the design doc to each MachO method. Place new overloads in a `// MARK: - ReadingContext Support` extension at the bottom of each file.
+
+For `Class.swift` (the highest-level wrapper): mirror the `init(descriptor:in:)` and any other MachO-parameterized methods, calling `.someMethod(in: context)` for nested calls instead of `.someMethod(in: machO)`.
+
+For `ClassDescriptor.swift`: mirror every descriptor method one-by-one.
+
+For metadata protocols: mirror every method that reads through `machO`.
+
+- [ ] **Step 3: Build**
+
+```bash
+swift build 2>&1 | xcsift
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/MachOSwiftSection/Models/Type/Class/
+git commit -m "feat(MachOSwiftSection): add ReadingContext API for class types
+
+Mirror the MachO overloads on Class, ClassDescriptor, the AnyClassMetadata
+and FinalClassMetadata protocols, and the Method*Descriptor types. Call
+sites pass the context through to nested methods so the unified path is
+end-to-end."
+```
+
+---
+
+## Task 5: `Type/Enum/`, `Type/Struct/`
+
+**Files:**
+- Modify: `Sources/MachOSwiftSection/Models/Type/Enum/Enum.swift`
+- Modify: `Sources/MachOSwiftSection/Models/Type/Enum/Metadata/EnumMetadataProtocol.swift`
+- Modify: `Sources/MachOSwiftSection/Models/Type/Enum/MultiPayloadEnumDescriptor.swift`
+- Modify: `Sources/MachOSwiftSection/Models/Type/Struct/Struct.swift`
+- Modify: `Sources/MachOSwiftSection/Models/Type/Struct/StructMetadataProtocol.swift`
+
+- [ ] **Step 1: Add ReadingContext overloads to each file**
+
+For each file, list every method whose signature uses `<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO)` and add a sibling `<Context: ReadingContext>(in context: Context)` overload using the substitution table from the design doc. Place new overloads in a `// MARK: - ReadingContext Support` extension at the bottom of each file.
+
+Specifics for this batch:
+- `Enum.swift` and `Struct.swift`: mirror `init(descriptor:in:)` so the value-type wrappers can be built from a `ReadingContext`. Pass `in: context` to all nested `descriptor.someMethod(in: ...)` calls.
+- `EnumMetadataProtocol` and `StructMetadataProtocol`: mirror metadata-reading methods (e.g. `payloadCases`, `typeDescriptor`).
+- `MultiPayloadEnumDescriptor`: mirror payload-tag and case helpers.
+
+- [ ] **Step 2: Build**
+
+```bash
+swift build 2>&1 | xcsift
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/MachOSwiftSection/Models/Type/Enum/ \
+        Sources/MachOSwiftSection/Models/Type/Struct/
+git commit -m "feat(MachOSwiftSection): add ReadingContext API for enum/struct types
+
+Mirror init(descriptor:in:) and metadata helpers on Enum, Struct,
+EnumMetadataProtocol, StructMetadataProtocol, and
+MultiPayloadEnumDescriptor."
+```
+
+---
+
+## Task 6: `Type/` root files (descriptor, references, value metadata)
+
+**Files:**
+- Modify: `Sources/MachOSwiftSection/Models/Type/TypeContextDescriptor.swift`
+- Modify: `Sources/MachOSwiftSection/Models/Type/TypeContextWrapper.swift`
+- Modify: `Sources/MachOSwiftSection/Models/Type/TypeReference.swift`
+- Modify: `Sources/MachOSwiftSection/Models/Type/ValueMetadataProtocol.swift`
+- Modify (partial top-up): `Sources/MachOSwiftSection/Models/Type/TypeContextDescriptorProtocol.swift`
+
+- [ ] **Step 1: Add ReadingContext overloads to the four uncovered files**
+
+Same procedure as prior batches.
+
+- [ ] **Step 2: Top up `TypeContextDescriptorProtocol.swift`**
+
+The file already has `genericContext(in:Context)` and `typeGenericContext(in:Context)`. Add the missing `fieldDescriptor(in:Context)` and `metadataAccessorFunction(in:Context)`:
+
+```swift
+extension TypeContextDescriptorProtocol {
+    public func fieldDescriptor<Context: ReadingContext>(in context: Context) throws -> FieldDescriptor {
+        let address = try context.addressFromOffset(offset + layout.offset(of: .fieldDescriptor))
+        return try layout.fieldDescriptor.resolve(at: address, in: context)
+    }
+
+    public func metadataAccessorFunction<Context: ReadingContext>(in context: Context) throws -> MetadataAccessorFunction? {
+        let fieldAddress = try context.addressFromOffset(offset + layout.offset(of: .accessFunctionPtr))
+        let relativeOffset: Int32 = try context.readElement(at: fieldAddress)
+        let targetAddress = context.advanceAddress(fieldAddress, by: Int(relativeOffset))
+        return try context.runtimePointer(at: targetAddress).map { MetadataAccessorFunction(ptr: $0) }
+    }
+}
+```
+
+The `metadataAccessorFunction(in:Context)` returns `nil` for `MachOContext<MachOFile>` (matching the existing MachO overload), and returns the function pointer for `InProcessContext` and `MachOContext<MachOImage>`.
+
+- [ ] **Step 3: Build**
+
+```bash
+swift build 2>&1 | xcsift
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/MachOSwiftSection/Models/Type/TypeContextDescriptor.swift \
+        Sources/MachOSwiftSection/Models/Type/TypeContextWrapper.swift \
+        Sources/MachOSwiftSection/Models/Type/TypeReference.swift \
+        Sources/MachOSwiftSection/Models/Type/ValueMetadataProtocol.swift \
+        Sources/MachOSwiftSection/Models/Type/TypeContextDescriptorProtocol.swift
+git commit -m "feat(MachOSwiftSection): add ReadingContext API for Type root descriptors
+
+Mirror MachO overloads on TypeContextDescriptor, TypeContextWrapper,
+TypeReference, and ValueMetadataProtocol. Add the missing
+fieldDescriptor(in:context:) and metadataAccessorFunction(in:context:)
+overloads on TypeContextDescriptorProtocol — the latter uses the new
+runtimePointer(at:) extension to return the function pointer for
+InProcess and MachOImage contexts and nil for MachOFile."
+```
+
+---
+
+## Task 7: `Protocol/`, `ProtocolConformance/`
+
+**Files:**
+- Modify: `Sources/MachOSwiftSection/Models/Protocol/Protocol.swift`
+- Modify: `Sources/MachOSwiftSection/Models/Protocol/ProtocolDescriptor.swift`
+- Modify: `Sources/MachOSwiftSection/Models/Protocol/ProtocolDescriptorRef.swift`
+- Modify: `Sources/MachOSwiftSection/Models/Protocol/ProtocolRecord.swift`
+- Modify: `Sources/MachOSwiftSection/Models/Protocol/ProtocolRequirement.swift`
+- Modify: `Sources/MachOSwiftSection/Models/Protocol/ResilientWitness.swift`
+- Modify: `Sources/MachOSwiftSection/Models/ProtocolConformance/GlobalActorReference.swift`
+- Modify: `Sources/MachOSwiftSection/Models/ProtocolConformance/ProtocolConformance.swift`
+- Modify: `Sources/MachOSwiftSection/Models/ProtocolConformance/ProtocolConformanceDescriptor.swift`
+
+- [ ] **Step 1: Add ReadingContext overloads to each file**
+
+For each file, list every method whose signature uses `<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO)` and add a sibling `<Context: ReadingContext>(in context: Context)` overload using the substitution table from the design doc. Place new overloads in a `// MARK: - ReadingContext Support` extension at the bottom of each file.
+
+Note: `Protocol.swift` and `ProtocolConformance.swift` are the highest-level wrappers — their `init(descriptor:in:Context)` overloads are required by Task 11 (`ContextWrapper.forContextDescriptorWrapper(_:in:context:)`), so do not skip them.
+
+- [ ] **Step 2: Build**
+
+```bash
+swift build 2>&1 | xcsift
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/MachOSwiftSection/Models/Protocol/ \
+        Sources/MachOSwiftSection/Models/ProtocolConformance/
+git commit -m "feat(MachOSwiftSection): add ReadingContext API for protocol/conformance types
+
+Mirror MachO overloads on Protocol, ProtocolDescriptor, ProtocolDescriptorRef,
+ProtocolRecord, ProtocolRequirement, ResilientWitness, GlobalActorReference,
+ProtocolConformance, and ProtocolConformanceDescriptor."
+```
+
+---
+
+## Task 8: `Generic/`, `FieldDescriptor/`, `FieldRecord/`, `AssociatedType/`
+
+**Files:**
+- Modify: `Sources/MachOSwiftSection/Models/Generic/GenericRequirement.swift`
+- Modify: `Sources/MachOSwiftSection/Models/FieldDescriptor/FieldDescriptor.swift`
+- Modify: `Sources/MachOSwiftSection/Models/FieldRecord/FieldRecord.swift`
+- Modify: `Sources/MachOSwiftSection/Models/AssociatedType/AssociatedType.swift`
+- Modify: `Sources/MachOSwiftSection/Models/AssociatedType/AssociatedTypeDescriptor.swift`
+- Modify: `Sources/MachOSwiftSection/Models/AssociatedType/AssociatedTypeRecord.swift`
+
+- [ ] **Step 1: Add ReadingContext overloads to each file**
+
+For each file, list every method whose signature uses `<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO)` and add a sibling `<Context: ReadingContext>(in context: Context)` overload using the substitution table from the design doc. Place new overloads in a `// MARK: - ReadingContext Support` extension at the bottom of each file.
+
+Note: `GenericRequirement.swift` only needs an `init(descriptor:in:Context)` mirror — `paramMangledName(in:Context)` and `resolvedContent(in:Context)` already exist on `GenericRequirementDescriptor` (one of the partial files).
+
+- [ ] **Step 2: Build**
+
+```bash
+swift build 2>&1 | xcsift
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/MachOSwiftSection/Models/Generic/GenericRequirement.swift \
+        Sources/MachOSwiftSection/Models/FieldDescriptor/ \
+        Sources/MachOSwiftSection/Models/FieldRecord/ \
+        Sources/MachOSwiftSection/Models/AssociatedType/
+git commit -m "feat(MachOSwiftSection): add ReadingContext API for generic/field/associated-type
+
+Mirror MachO overloads on GenericRequirement, FieldDescriptor, FieldRecord,
+and the AssociatedType family."
+```
+
+---
+
+## Task 9: `Metadata/` (protocols and wrappers)
+
+**Files:**
+- Modify: `Sources/MachOSwiftSection/Models/Metadata/MetadataProtocol.swift`
+- Modify: `Sources/MachOSwiftSection/Models/Metadata/MetadataWrapper.swift`
+
+- [ ] **Step 1: Add ReadingContext overloads to each file**
+
+For each file, list every method whose signature uses `<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO)` and add a sibling `<Context: ReadingContext>(in context: Context)` overload using the substitution table from the design doc. Place new overloads in a `// MARK: - ReadingContext Support` extension at the bottom of each file.
+
+Specifics for this batch:
+- `MetadataProtocol`: mirror metadata-reading methods (e.g. `valueWitnessTable`, `typeContextDescriptor`, kind-specific accessors).
+- `MetadataWrapper`: mirror the static `forMetadata(_:in:)` factory (the switch over metadata kinds) and any wrapper-level methods that take `in: machO`.
+
+- [ ] **Step 2: Build**
+
+```bash
+swift build 2>&1 | xcsift
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/MachOSwiftSection/Models/Metadata/MetadataProtocol.swift \
+        Sources/MachOSwiftSection/Models/Metadata/MetadataWrapper.swift
+git commit -m "feat(MachOSwiftSection): add ReadingContext API for Metadata protocol/wrapper"
+```
+
+---
+
+## Task 10: `ExistentialType/`, `ForeignType/`, `TupleType/`, `OpaqueType/`, `BuiltinType/`
+
+**Files:**
+- Modify: `Sources/MachOSwiftSection/Models/ExistentialType/ExistentialTypeMetadata.swift`
+- Modify: `Sources/MachOSwiftSection/Models/ForeignType/ForeignClassMetadata.swift`
+- Modify: `Sources/MachOSwiftSection/Models/ForeignType/ForeignReferenceTypeMetadata.swift`
+- Modify: `Sources/MachOSwiftSection/Models/TupleType/TupleTypeMetadata.swift`
+- Modify: `Sources/MachOSwiftSection/Models/OpaqueType/OpaqueType.swift`
+- Modify: `Sources/MachOSwiftSection/Models/BuiltinType/BuiltinType.swift`
+- Modify: `Sources/MachOSwiftSection/Models/BuiltinType/BuiltinTypeDescriptor.swift`
+
+- [ ] **Step 1: Add ReadingContext overloads to each file**
+
+For each file, list every method whose signature uses `<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO)` and add a sibling `<Context: ReadingContext>(in context: Context)` overload using the substitution table from the design doc. Place new overloads in a `// MARK: - ReadingContext Support` extension at the bottom of each file.
+
+These are the remaining metadata wrappers — most have one to three methods each. Read each file end-to-end before mirroring.
+
+- [ ] **Step 2: Build**
+
+```bash
+swift build 2>&1 | xcsift
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/MachOSwiftSection/Models/ExistentialType/ \
+        Sources/MachOSwiftSection/Models/ForeignType/ \
+        Sources/MachOSwiftSection/Models/TupleType/ \
+        Sources/MachOSwiftSection/Models/OpaqueType/ \
+        Sources/MachOSwiftSection/Models/BuiltinType/
+git commit -m "feat(MachOSwiftSection): add ReadingContext API for remaining metadata types
+
+Mirror MachO overloads on ExistentialTypeMetadata, ForeignClassMetadata,
+ForeignReferenceTypeMetadata, TupleTypeMetadata, OpaqueType, BuiltinType,
+and BuiltinTypeDescriptor."
+```
+
+---
+
+## Task 11: `ContextWrapper.forContextDescriptorWrapper(_:in:context:)`
+
+**Files:**
+- Modify: `Sources/MachOSwiftSection/Models/ContextDescriptor/ContextWrapper.swift`
+
+This was deferred from Task 3 because it depends on every concrete Context type having a `init(descriptor:in:Context)` overload, which Tasks 2/4/5/6/7 add.
+
+- [ ] **Step 1: Add `forContextDescriptorWrapper(_:in:Context)` to `ContextWrapper.swift`**
+
+Inside the existing `// MARK: - ReadingContext Support` extension (added in Task 3), add:
+
+```swift
+public static func forContextDescriptorWrapper<Context: ReadingContext>(_ contextDescriptorWrapper: ContextDescriptorWrapper, in context: Context) throws -> Self {
+    switch contextDescriptorWrapper {
+    case .type(let typeContextDescriptorWrapper):
+        switch typeContextDescriptorWrapper {
+        case .enum(let enumDescriptor):
+            return try .type(.enum(.init(descriptor: enumDescriptor, in: context)))
+        case .struct(let structDescriptor):
+            return try .type(.struct(.init(descriptor: structDescriptor, in: context)))
+        case .class(let classDescriptor):
+            return try .type(.class(.init(descriptor: classDescriptor, in: context)))
+        }
+    case .protocol(let protocolDescriptor):
+        return try .protocol(.init(descriptor: protocolDescriptor, in: context))
+    case .anonymous(let anonymousContextDescriptor):
+        return try .anonymous(.init(descriptor: anonymousContextDescriptor, in: context))
+    case .extension(let extensionContextDescriptor):
+        return try .extension(.init(descriptor: extensionContextDescriptor, in: context))
+    case .module(let moduleContextDescriptor):
+        return try .module(.init(descriptor: moduleContextDescriptor, in: context))
+    case .opaqueType(let opaqueTypeDescriptor):
+        return try .opaqueType(.init(descriptor: opaqueTypeDescriptor, in: context))
+    }
+}
+```
+
+Also retrofit the `parent(in:context:)` method added in Task 3 to call this new helper instead of inlining it (search for the eight `forContextDescriptorWrapper($0, in: context)` call sites — they should already be calling this name; this step just adds the actual implementation).
+
+- [ ] **Step 2: Build**
+
+```bash
+swift build 2>&1 | xcsift
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/MachOSwiftSection/Models/ContextDescriptor/ContextWrapper.swift
+git commit -m "feat(MachOSwiftSection): wire ContextWrapper.forContextDescriptorWrapper for ReadingContext
+
+Now that every concrete Context type has an init(descriptor:in:Context)
+overload (Tasks 2/4/5/6/7), implement the ReadingContext version of
+forContextDescriptorWrapper that the parent(in:context:) helper depends on."
+```
+
+---
+
+## Task 12: Audit partial files, sweep for missed methods, full test pass
+
+**Files:**
+- Audit (no expected modifications): all 15 files that already had partial ReadingContext support, listed below.
+
+The 15 partially-implemented files were:
+
+```
+Models/Anonymous/AnonymousContextDescriptorProtocol.swift
+Models/ContextDescriptor/ContextDescriptorProtocol.swift
+Models/ContextDescriptor/ContextDescriptorWrapper.swift
+Models/ContextDescriptor/NamedContextDescriptorProtocol.swift
+Models/ExistentialType/ExtendedExistentialTypeShape.swift
+Models/ExistentialType/NonUniqueExtendedExistentialTypeShape.swift
+Models/Extension/ExtensionContextDescriptor.swift
+Models/Generic/GenericContext.swift
+Models/Generic/GenericRequirementDescriptor.swift
+Models/Mangling/MangledName.swift
+Models/Protocol/ObjC/ObjCProtocolPrefix.swift
+Models/Protocol/ObjC/RelativeObjCProtocolPrefix.swift
+Models/Type/TypeContextDescriptorProtocol.swift   (already topped up in Task 6)
+Models/Type/TypeContextDescriptorWrapper.swift
+Models/Type/TypeMetadataRecord.swift
+```
+
+- [ ] **Step 1: Per-file audit**
+
+For each of the 15 files, list its `<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO)` methods and its `<Context: ReadingContext>(in context: Context)` methods. Any MachO method without a sibling ReadingContext method is a gap — add it using the same substitution table. Skip files with no gap.
+
+Run this command to surface gaps quickly:
+
+```bash
+for f in $(grep -l "Context: ReadingContext" Sources/MachOSwiftSection/Models/ -r); do
+  echo "=== $f ==="
+  grep -E "func .*<(MachO|Context):" "$f" | sed -E 's/.*func ([a-zA-Z]+)<(MachO|Context).*/\1 \2/'
+done
+```
+
+Look for method names that appear with `MachO` but not with `Context`.
+
+- [ ] **Step 2: Add missing ReadingContext overloads found in Step 1**
+
+Apply the substitution table. If no gaps were found, this step is a no-op.
+
+- [ ] **Step 3: Full test pass**
+
+```bash
+swift package update && swift test 2>&1 | xcsift
+```
+
+Expected: existing tests pass (`MachOSwiftSectionTests`, `DemanglingTests`, `SwiftDumpTests`, `SwiftInterfaceTests`). No new tests are introduced by this work.
+
+If a test fails: read the failure carefully. The most likely cause is a typo in a substitution (e.g. forgot `try`, wrong type cast). Fix in place and re-run.
+
+- [ ] **Step 4: Final coverage check**
+
+Run the gap query from the design doc one more time:
+
+```bash
+grep -lL "ReadingContext" $(grep -l "MachOSwiftSectionRepresentableWithCache" \
+  Sources/MachOSwiftSection/Models/ -r)
+```
+
+Expected: empty output (every model file with a MachO API now has a ReadingContext API).
+
+- [ ] **Step 5: Commit (only if Step 2 produced changes; otherwise skip)**
+
+```bash
+git add Sources/MachOSwiftSection/Models/
+git commit -m "feat(MachOSwiftSection): close ReadingContext gaps in partial files
+
+Audit pass over the 15 files that previously had partial ReadingContext
+coverage. Adds the few overloads that were missing relative to each
+file's MachO API surface."
+```
+
+---
+
+## Done
+
+After Task 12, the entire `Sources/MachOSwiftSection/Models/` tree exposes a complete `ReadingContext` API mirror, the `runtimePointer(at:)` extension is in place, and `swift test` passes.

--- a/docs/superpowers/plans/2026-05-02-reading-context-api.md
+++ b/docs/superpowers/plans/2026-05-02-reading-context-api.md
@@ -223,7 +223,7 @@ ModuleContext, and ExtensionContext under the ReadingContext abstraction."
 
 `ContextProtocol` exposes `parent(in: machO)`. `ContextWrapper` exposes `parent(in: machO)` and `forContextDescriptorWrapper(_:in:)`. Mirror both.
 
-- [ ] **Step 1: Add ReadingContext extension to `ContextProtocol.swift`**
+- [x] **Step 1: Add ReadingContext extension to `ContextProtocol.swift`**
 
 Append at bottom:
 
@@ -237,7 +237,7 @@ extension ContextProtocol {
 }
 ```
 
-- [ ] **Step 2: Add ReadingContext methods to `ContextWrapper.swift`**
+- [x] **Step 2: Add ReadingContext methods to `ContextWrapper.swift`**
 
 Append at bottom (after the existing `parent()` method):
 
@@ -299,13 +299,13 @@ extension ContextWrapper {
 
 **Recommended:** Land *only* the `parent(in:context:)` portion now (which depends on `descriptor.parent(in:context:)` already provided by `ContextDescriptorProtocol`), and defer `forContextDescriptorWrapper(_:in:context:)` to a later task (Task 11) once all `init(descriptor:in:context:)` overloads exist.
 
-- [ ] **Step 3: Build**
+- [x] **Step 3: Build**
 
 ```bash
 swift build 2>&1 | xcsift
 ```
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add Sources/MachOSwiftSection/Models/ContextDescriptor/ContextProtocol.swift \
@@ -316,6 +316,8 @@ Adds parent(in:context:) on both. forContextDescriptorWrapper(_:in:context:)
 is deferred until concrete Context types have their ReadingContext init
 overloads (Task 11)."
 ```
+
+Combined with Task 11 below into a single commit `d5d1d74` since the dependency only resolves once all concrete `init(descriptor:in:Context)` overloads exist.
 
 ---
 
@@ -597,25 +599,27 @@ For each file, list every method whose signature uses `<MachO: MachOSwiftSection
 
 These are the remaining metadata wrappers — most have one to three methods each. Read each file end-to-end before mirroring.
 
-- [ ] **Step 2: Build**
+- [x] **Step 2: Build**
 
 ```bash
 swift build 2>&1 | xcsift
 ```
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add Sources/MachOSwiftSection/Models/ExistentialType/ \
-        Sources/MachOSwiftSection/Models/ForeignType/ \
         Sources/MachOSwiftSection/Models/TupleType/ \
         Sources/MachOSwiftSection/Models/OpaqueType/ \
         Sources/MachOSwiftSection/Models/BuiltinType/
 git commit -m "feat(MachOSwiftSection): add ReadingContext API for remaining metadata types
 
-Mirror MachO overloads on ExistentialTypeMetadata, ForeignClassMetadata,
-ForeignReferenceTypeMetadata, TupleTypeMetadata, OpaqueType, BuiltinType,
-and BuiltinTypeDescriptor."
+Mirror MachO overloads on ExistentialTypeMetadata, TupleTypeMetadata,
+OpaqueType, BuiltinType, and BuiltinTypeDescriptor.
+
+ForeignClassMetadata.classDescriptor and
+ForeignReferenceTypeMetadata.classDescriptor were added as prerequisites
+in the preceding Metadata batch."
 ```
 
 ---
@@ -627,7 +631,7 @@ and BuiltinTypeDescriptor."
 
 This was deferred from Task 3 because it depends on every concrete Context type having a `init(descriptor:in:Context)` overload, which Tasks 2/4/5/6/7 add.
 
-- [ ] **Step 1: Add `forContextDescriptorWrapper(_:in:Context)` to `ContextWrapper.swift`**
+- [x] **Step 1: Add `forContextDescriptorWrapper(_:in:Context)` to `ContextWrapper.swift`**
 
 Inside the existing `// MARK: - ReadingContext Support` extension (added in Task 3), add:
 
@@ -659,21 +663,28 @@ public static func forContextDescriptorWrapper<Context: ReadingContext>(_ contex
 
 Also retrofit the `parent(in:context:)` method added in Task 3 to call this new helper instead of inlining it (search for the eight `forContextDescriptorWrapper($0, in: context)` call sites — they should already be calling this name; this step just adds the actual implementation).
 
-- [ ] **Step 2: Build**
+- [x] **Step 2: Build**
 
 ```bash
 swift build 2>&1 | xcsift
 ```
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
-```bash
-git add Sources/MachOSwiftSection/Models/ContextDescriptor/ContextWrapper.swift
-git commit -m "feat(MachOSwiftSection): wire ContextWrapper.forContextDescriptorWrapper for ReadingContext
+Combined with Task 3 above into a single commit `d5d1d74` with body:
 
-Now that every concrete Context type has an init(descriptor:in:Context)
-overload (Tasks 2/4/5/6/7), implement the ReadingContext version of
-forContextDescriptorWrapper that the parent(in:context:) helper depends on."
+```
+feat(MachOSwiftSection): wire ContextProtocol/ContextWrapper for ReadingContext
+
+Add parent(in:context:) on ContextProtocol and ContextWrapper, and the
+forContextDescriptorWrapper(_:in:context:) static factory on ContextWrapper.
+
+These three methods were deferred from earlier batches because
+forContextDescriptorWrapper(_:in:context:) depends on every concrete
+Context type having an init(descriptor:in:context:) overload — and those
+landed across Tasks 2, 4, 5, 6, and 7. Now that all dependencies exist,
+this commit closes the dependency and completes the parent traversal API
+under the unified ReadingContext abstraction.
 ```
 
 ---
@@ -703,7 +714,7 @@ Models/Type/TypeContextDescriptorWrapper.swift
 Models/Type/TypeMetadataRecord.swift
 ```
 
-- [ ] **Step 1: Per-file audit**
+- [x] **Step 1: Per-file audit**
 
 For each of the 15 files, list its `<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO)` methods and its `<Context: ReadingContext>(in context: Context)` methods. Any MachO method without a sibling ReadingContext method is a gap — add it using the same substitution table. Skip files with no gap.
 
@@ -718,11 +729,11 @@ done
 
 Look for method names that appear with `MachO` but not with `Context`.
 
-- [ ] **Step 2: Add missing ReadingContext overloads found in Step 1**
+- [x] **Step 2: Add missing ReadingContext overloads found in Step 1**
 
 Apply the substitution table. If no gaps were found, this step is a no-op.
 
-- [ ] **Step 3: Full test pass**
+- [x] **Step 3: Full test pass**
 
 ```bash
 swift package update && swift test 2>&1 | xcsift
@@ -732,7 +743,7 @@ Expected: existing tests pass (`MachOSwiftSectionTests`, `DemanglingTests`, `Swi
 
 If a test fails: read the failure carefully. The most likely cause is a typo in a substitution (e.g. forgot `try`, wrong type cast). Fix in place and re-run.
 
-- [ ] **Step 4: Final coverage check**
+- [x] **Step 4: Final coverage check**
 
 Run the gap query from the design doc one more time:
 
@@ -743,7 +754,7 @@ grep -lL "ReadingContext" $(grep -l "MachOSwiftSectionRepresentableWithCache" \
 
 Expected: empty output (every model file with a MachO API now has a ReadingContext API).
 
-- [ ] **Step 5: Commit (only if Step 2 produced changes; otherwise skip)**
+- [x] **Step 5: Commit (only if Step 2 produced changes; otherwise skip)**
 
 ```bash
 git add Sources/MachOSwiftSection/Models/

--- a/docs/superpowers/plans/2026-05-02-reading-context-api.md
+++ b/docs/superpowers/plans/2026-05-02-reading-context-api.md
@@ -33,7 +33,7 @@ These are rules the implementer follows for every batch — the per-task steps b
 - Modify: `Sources/MachOReading/ReadingContext/MachOContext.swift` (append extension)
 - Modify: `Sources/MachOReading/ReadingContext/InProcessContext.swift` (append extension)
 
-- [ ] **Step 1: Read the three target files end-to-end**
+- [x] **Step 1: Read the three target files end-to-end**
 
 Read all three files completely so the extension placement matches existing style (imports, doc comment style, ordering).
 
@@ -42,7 +42,7 @@ Read all three files completely so the extension placement matches existing styl
 grep -n "import" Sources/MachOReading/ReadingContext/MachOContext.swift
 ```
 
-- [ ] **Step 2: Append default extension to `ReadingContext.swift`**
+- [x] **Step 2: Append default extension to `ReadingContext.swift`**
 
 After the existing `extension ReadingContext { ... bindRebaseResolver default ... }` block, add:
 
@@ -65,7 +65,7 @@ extension ReadingContext {
 }
 ```
 
-- [ ] **Step 3: Append override to `MachOContext.swift`**
+- [x] **Step 3: Append override to `MachOContext.swift`**
 
 At the bottom of the file (after the `Convenience Extensions` MARK):
 
@@ -85,7 +85,7 @@ extension MachOContext {
 }
 ```
 
-- [ ] **Step 4: Append override to `InProcessContext.swift`**
+- [x] **Step 4: Append override to `InProcessContext.swift`**
 
 At the bottom of the file:
 
@@ -101,7 +101,7 @@ extension InProcessContext {
 }
 ```
 
-- [ ] **Step 5: Build**
+- [x] **Step 5: Build**
 
 ```bash
 swift package update && swift build 2>&1 | xcsift
@@ -109,7 +109,7 @@ swift package update && swift build 2>&1 | xcsift
 
 Expected: build succeeds.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add Sources/MachOReading/ReadingContext/ReadingContext.swift \
@@ -135,7 +135,7 @@ abstraction without per-call type dispatch."
 
 These three files each have a MachO `init(descriptor:in:)` and an InProcess `init(descriptor:)`. Add a third `init(descriptor:in:Context)` mirroring the MachO version.
 
-- [ ] **Step 1: Add `init(descriptor:in:Context)` to `AnonymousContext.swift`**
+- [x] **Step 1: Add `init(descriptor:in:Context)` to `AnonymousContext.swift`**
 
 Append at bottom:
 
@@ -163,7 +163,7 @@ extension AnonymousContext {
 }
 ```
 
-- [ ] **Step 2: Add `init(descriptor:in:Context)` to `ModuleContext.swift`**
+- [x] **Step 2: Add `init(descriptor:in:Context)` to `ModuleContext.swift`**
 
 Append at bottom:
 
@@ -178,7 +178,7 @@ extension ModuleContext {
 
 (`name(in: Context)` already exists on `NamedContextDescriptorProtocol`.)
 
-- [ ] **Step 3: Add `init(descriptor:in:Context)` to `ExtensionContext.swift`**
+- [x] **Step 3: Add `init(descriptor:in:Context)` to `ExtensionContext.swift`**
 
 Append at bottom:
 
@@ -194,13 +194,13 @@ extension ExtensionContext {
 
 If `extendedContext(in: Context)` does not yet exist on `ExtensionContextDescriptor`, add it first inside `Sources/MachOSwiftSection/Models/Extension/ExtensionContextDescriptor.swift` mirroring the MachO version, then complete this step.
 
-- [ ] **Step 4: Build**
+- [x] **Step 4: Build**
 
 ```bash
 swift build 2>&1 | xcsift
 ```
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add Sources/MachOSwiftSection/Models/Anonymous/AnonymousContext.swift \
@@ -331,11 +331,11 @@ overloads (Task 11)."
 - Modify: `Sources/MachOSwiftSection/Models/Type/Class/Method/MethodOverrideDescriptor.swift`
 - Modify: `Sources/MachOSwiftSection/Models/Type/Class/Method/MethodDefaultOverrideDescriptor.swift`
 
-- [ ] **Step 1: Read each file end-to-end**
+- [x] **Step 1: Read each file end-to-end**
 
 For each of the 8 files, list every method with a `<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO)` signature. Those are the methods that need a sibling `<Context: ReadingContext>(in context: Context)` overload.
 
-- [ ] **Step 2: Add ReadingContext overloads to each file**
+- [x] **Step 2: Add ReadingContext overloads to each file**
 
 Apply the substitution table from the design doc to each MachO method. Place new overloads in a `// MARK: - ReadingContext Support` extension at the bottom of each file.
 
@@ -345,13 +345,13 @@ For `ClassDescriptor.swift`: mirror every descriptor method one-by-one.
 
 For metadata protocols: mirror every method that reads through `machO`.
 
-- [ ] **Step 3: Build**
+- [x] **Step 3: Build**
 
 ```bash
 swift build 2>&1 | xcsift
 ```
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add Sources/MachOSwiftSection/Models/Type/Class/
@@ -374,7 +374,7 @@ end-to-end."
 - Modify: `Sources/MachOSwiftSection/Models/Type/Struct/Struct.swift`
 - Modify: `Sources/MachOSwiftSection/Models/Type/Struct/StructMetadataProtocol.swift`
 
-- [ ] **Step 1: Add ReadingContext overloads to each file**
+- [x] **Step 1: Add ReadingContext overloads to each file**
 
 For each file, list every method whose signature uses `<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO)` and add a sibling `<Context: ReadingContext>(in context: Context)` overload using the substitution table from the design doc. Place new overloads in a `// MARK: - ReadingContext Support` extension at the bottom of each file.
 
@@ -383,13 +383,13 @@ Specifics for this batch:
 - `EnumMetadataProtocol` and `StructMetadataProtocol`: mirror metadata-reading methods (e.g. `payloadCases`, `typeDescriptor`).
 - `MultiPayloadEnumDescriptor`: mirror payload-tag and case helpers.
 
-- [ ] **Step 2: Build**
+- [x] **Step 2: Build**
 
 ```bash
 swift build 2>&1 | xcsift
 ```
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add Sources/MachOSwiftSection/Models/Type/Enum/ \
@@ -412,11 +412,11 @@ MultiPayloadEnumDescriptor."
 - Modify: `Sources/MachOSwiftSection/Models/Type/ValueMetadataProtocol.swift`
 - Modify (partial top-up): `Sources/MachOSwiftSection/Models/Type/TypeContextDescriptorProtocol.swift`
 
-- [ ] **Step 1: Add ReadingContext overloads to the four uncovered files**
+- [x] **Step 1: Add ReadingContext overloads to the four uncovered files**
 
 Same procedure as prior batches.
 
-- [ ] **Step 2: Top up `TypeContextDescriptorProtocol.swift`**
+- [x] **Step 2: Top up `TypeContextDescriptorProtocol.swift`**
 
 The file already has `genericContext(in:Context)` and `typeGenericContext(in:Context)`. Add the missing `fieldDescriptor(in:Context)` and `metadataAccessorFunction(in:Context)`:
 
@@ -438,13 +438,13 @@ extension TypeContextDescriptorProtocol {
 
 The `metadataAccessorFunction(in:Context)` returns `nil` for `MachOContext<MachOFile>` (matching the existing MachO overload), and returns the function pointer for `InProcessContext` and `MachOContext<MachOImage>`.
 
-- [ ] **Step 3: Build**
+- [x] **Step 3: Build**
 
 ```bash
 swift build 2>&1 | xcsift
 ```
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add Sources/MachOSwiftSection/Models/Type/TypeContextDescriptor.swift \
@@ -459,7 +459,11 @@ TypeReference, and ValueMetadataProtocol. Add the missing
 fieldDescriptor(in:context:) and metadataAccessorFunction(in:context:)
 overloads on TypeContextDescriptorProtocol — the latter uses the new
 runtimePointer(at:) extension to return the function pointer for
-InProcess and MachOImage contexts and nil for MachOFile."
+InProcess and MachOImage contexts and nil for MachOFile.
+
+Also retarget EnumMetadataProtocol.enumDescriptor and
+StructMetadataProtocol.structDescriptor to call descriptor(in:context:)
+now that the helper exists."
 ```
 
 ---
@@ -477,19 +481,19 @@ InProcess and MachOImage contexts and nil for MachOFile."
 - Modify: `Sources/MachOSwiftSection/Models/ProtocolConformance/ProtocolConformance.swift`
 - Modify: `Sources/MachOSwiftSection/Models/ProtocolConformance/ProtocolConformanceDescriptor.swift`
 
-- [ ] **Step 1: Add ReadingContext overloads to each file**
+- [x] **Step 1: Add ReadingContext overloads to each file**
 
 For each file, list every method whose signature uses `<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO)` and add a sibling `<Context: ReadingContext>(in context: Context)` overload using the substitution table from the design doc. Place new overloads in a `// MARK: - ReadingContext Support` extension at the bottom of each file.
 
 Note: `Protocol.swift` and `ProtocolConformance.swift` are the highest-level wrappers — their `init(descriptor:in:Context)` overloads are required by Task 11 (`ContextWrapper.forContextDescriptorWrapper(_:in:context:)`), so do not skip them.
 
-- [ ] **Step 2: Build**
+- [x] **Step 2: Build**
 
 ```bash
 swift build 2>&1 | xcsift
 ```
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add Sources/MachOSwiftSection/Models/Protocol/ \
@@ -500,6 +504,10 @@ Mirror MachO overloads on Protocol, ProtocolDescriptor, ProtocolDescriptorRef,
 ProtocolRecord, ProtocolRequirement, ResilientWitness, GlobalActorReference,
 ProtocolConformance, and ProtocolConformanceDescriptor."
 ```
+
+The implementation also added two prerequisite mirrors needed by `Protocol.swift` and `ProtocolDescriptorRef.swift`:
+- `GenericRequirement.init<Context>` (would otherwise be in Task 8).
+- `ObjCProtocolPrefix.name<Context>` (a partial file from the Task 12 audit list).
 
 ---
 
@@ -513,29 +521,31 @@ ProtocolConformance, and ProtocolConformanceDescriptor."
 - Modify: `Sources/MachOSwiftSection/Models/AssociatedType/AssociatedTypeDescriptor.swift`
 - Modify: `Sources/MachOSwiftSection/Models/AssociatedType/AssociatedTypeRecord.swift`
 
-- [ ] **Step 1: Add ReadingContext overloads to each file**
+- [x] **Step 1: Add ReadingContext overloads to each file**
 
 For each file, list every method whose signature uses `<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO)` and add a sibling `<Context: ReadingContext>(in context: Context)` overload using the substitution table from the design doc. Place new overloads in a `// MARK: - ReadingContext Support` extension at the bottom of each file.
 
-Note: `GenericRequirement.swift` only needs an `init(descriptor:in:Context)` mirror — `paramMangledName(in:Context)` and `resolvedContent(in:Context)` already exist on `GenericRequirementDescriptor` (one of the partial files).
+Note: `GenericRequirement.swift` only needs an `init(descriptor:in:Context)` mirror — `paramMangledName(in:Context)` and `resolvedContent(in:Context)` already exist on `GenericRequirementDescriptor` (one of the partial files). Already added in Task 7 as a prerequisite, so this batch covers only the field/associated-type files.
 
-- [ ] **Step 2: Build**
+- [x] **Step 2: Build**
 
 ```bash
 swift build 2>&1 | xcsift
 ```
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
-git add Sources/MachOSwiftSection/Models/Generic/GenericRequirement.swift \
-        Sources/MachOSwiftSection/Models/FieldDescriptor/ \
+git add Sources/MachOSwiftSection/Models/FieldDescriptor/ \
         Sources/MachOSwiftSection/Models/FieldRecord/ \
         Sources/MachOSwiftSection/Models/AssociatedType/
 git commit -m "feat(MachOSwiftSection): add ReadingContext API for generic/field/associated-type
 
-Mirror MachO overloads on GenericRequirement, FieldDescriptor, FieldRecord,
-and the AssociatedType family."
+Mirror MachO overloads on FieldDescriptor, FieldRecord, and the
+AssociatedType family.
+
+GenericRequirement.init<Context> was added as a prerequisite in the
+preceding protocol/conformance batch."
 ```
 
 ---
@@ -546,7 +556,7 @@ and the AssociatedType family."
 - Modify: `Sources/MachOSwiftSection/Models/Metadata/MetadataProtocol.swift`
 - Modify: `Sources/MachOSwiftSection/Models/Metadata/MetadataWrapper.swift`
 
-- [ ] **Step 1: Add ReadingContext overloads to each file**
+- [x] **Step 1: Add ReadingContext overloads to each file**
 
 For each file, list every method whose signature uses `<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO)` and add a sibling `<Context: ReadingContext>(in context: Context)` overload using the substitution table from the design doc. Place new overloads in a `// MARK: - ReadingContext Support` extension at the bottom of each file.
 
@@ -554,13 +564,13 @@ Specifics for this batch:
 - `MetadataProtocol`: mirror metadata-reading methods (e.g. `valueWitnessTable`, `typeContextDescriptor`, kind-specific accessors).
 - `MetadataWrapper`: mirror the static `forMetadata(_:in:)` factory (the switch over metadata kinds) and any wrapper-level methods that take `in: machO`.
 
-- [ ] **Step 2: Build**
+- [x] **Step 2: Build**
 
 ```bash
 swift build 2>&1 | xcsift
 ```
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add Sources/MachOSwiftSection/Models/Metadata/MetadataProtocol.swift \

--- a/docs/superpowers/specs/2026-05-02-reading-context-api-design.md
+++ b/docs/superpowers/specs/2026-05-02-reading-context-api-design.md
@@ -1,0 +1,272 @@
+# ReadingContext API Coverage for `MachOSwiftSection/Models`
+
+**Date:** 2026-05-02
+**Status:** Approved, pending implementation
+**Branch:** `feature/reading-context-api` (to be created from `main`)
+
+## Problem
+
+Today, types and descriptors in
+`Sources/MachOSwiftSection/Models/` expose two parallel API families:
+
+1. **MachO-based**, parameterized over the backing file/image:
+   ```swift
+   func foo<MachO: MachOSwiftSectionRepresentableWithCache>(in machO: MachO) throws -> X
+   ```
+2. **InProcess**, no parameters, reading directly through the descriptor's
+   runtime pointer (`asPointer`):
+   ```swift
+   func foo() throws -> X
+   ```
+
+A third family — `ReadingContext`-based — has been introduced incrementally
+(see `Sources/MachOReading/ReadingContext/ReadingContext.swift`) and is meant
+to be the unified abstraction across the two reading modes:
+
+```swift
+func foo<Context: ReadingContext>(in context: Context) throws -> X
+```
+
+Today only ~15 of the ~60 model files that have a MachO API also expose a
+ReadingContext API. The remaining ~45 files are silently incomplete: any
+caller who already adopts the `ReadingContext` abstraction must drop down to
+the MachO/InProcess APIs, defeating the purpose.
+
+This document scopes a focused completion pass: add the missing
+`ReadingContext` overloads across `MachOSwiftSection/Models/`, mirroring the
+pattern already established in
+`Sources/MachOSwiftSection/Models/Type/TypeContextDescriptorProtocol.swift`
+and friends. While doing so, introduce one small protocol extension —
+`runtimePointer(at:)` — needed to express runtime-pointer-returning methods
+(notably `metadataAccessorFunction`) under the unified abstraction.
+
+## Goals
+
+- Provide a `ReadingContext`-based overload for every model method that
+  currently has a `MachOSwiftSectionRepresentableWithCache` overload, across
+  `MachOSwiftSection/Models/`.
+- Keep behavior identical to the existing implementations: the new overloads
+  are purely additive surface — no existing call sites change.
+- Add a minimal extension (`ReadingContext.runtimePointer(at:)`) so that
+  methods returning a runtime pointer (`metadataAccessorFunction`, and any
+  similar metadata pointer methods uncovered during the pass) can be
+  expressed cleanly without per-call type dispatch.
+- Land the work in reviewable, build-passing batches grouped by sub-directory.
+
+## Non-Goals
+
+- Touching modules outside `MachOSwiftSection/Models/`. The infrastructure
+  (`MachOReading`, `MachOPointers`, `MachOResolving`) already exposes
+  ReadingContext entry points — this work consumes them, it does not change
+  them — except for the single `runtimePointer(at:)` addition described
+  below.
+- Touching higher-level modules (`SwiftDump`, `SwiftInspection`,
+  `SwiftInterface`, `swift-section`). They keep using the existing MachO/
+  InProcess APIs. A follow-up branch can migrate them later.
+- Refactoring the existing MachO or InProcess overloads. They stay as-is.
+- Adding new unit tests. The new overloads are mechanical mirrors of
+  existing, tested code, and the underlying primitives
+  (`Resolvable.resolve(at:in:)`, `ReadingContext.read*`) are already covered
+  by their own tests.
+
+## Design
+
+### 1. Pattern for the common case
+
+For every method of the shape:
+
+```swift
+public func foo<MachO: MachOSwiftSectionRepresentableWithCache>(
+    in machO: MachO
+) throws -> X {
+    try layout.field.resolve(from: offset + layout.offset(of: .field), in: machO)
+}
+```
+
+add a sibling overload:
+
+```swift
+public func foo<Context: ReadingContext>(
+    in context: Context
+) throws -> X {
+    let address = try context.addressFromOffset(offset + layout.offset(of: .field))
+    return try layout.field.resolve(at: address, in: context)
+}
+```
+
+Substitution rules — applied mechanically per call:
+
+| MachO call | ReadingContext equivalent |
+|---|---|
+| `machO.readElement(offset: o)` | `context.readElement(at: try context.addressFromOffset(o))` |
+| `machO.readWrapperElement(offset: o)` | `context.readWrapperElement(at: try context.addressFromOffset(o))` |
+| `machO.readElements(offset: o, numberOfElements: n)` | `context.readElements(at: try context.addressFromOffset(o), numberOfElements: n)` |
+| `machO.readWrapperElements(offset: o, numberOfElements: n)` | `context.readWrapperElements(at: try context.addressFromOffset(o), numberOfElements: n)` |
+| `machO.readString(offset: o)` | `context.readString(at: try context.addressFromOffset(o))` |
+| `pointer.resolve(from: o, in: machO)` | `pointer.resolve(at: try context.addressFromOffset(o), in: context)` |
+| Recursive `someMethod(in: machO)` | `someMethod(in: context)` |
+
+Local offset arithmetic on `Int` (`currentOffset.offset(of:)`,
+`currentOffset.align(to:)`, `currentOffset += ...`) stays unchanged: the
+final translation to a context-specific address happens at the read site.
+
+Each new overload sits in a `// MARK: - ReadingContext Support` section
+inside the file. Existing MachO/InProcess code is left untouched.
+
+### 2. Extension to support runtime-pointer methods
+
+Some methods return a runtime function pointer
+(`metadataAccessorFunction` is the canonical example) and only make sense
+when the underlying reader is mapped into the current process. The MachO
+overload special-cases `MachO is MachOImage`; the InProcess overload uses
+`asPointer`.
+
+To express this under the unified abstraction without per-call
+`as?` dispatch, add a single optional capability to the protocol:
+
+```swift
+extension ReadingContext {
+    /// Converts a context-specific address to a runtime `UnsafeRawPointer`,
+    /// when the context is mapped into the current process.
+    ///
+    /// - `InProcessContext`: returns the address itself (already a pointer).
+    /// - `MachOContext<MachOImage>`: returns `machO.ptr + address`.
+    /// - `MachOContext<MachOFile>` / other readers: returns `nil`.
+    public func runtimePointer(at address: Address) throws -> UnsafeRawPointer? {
+        nil
+    }
+}
+```
+
+`InProcessContext` and `MachOContext` provide concrete overrides:
+
+```swift
+extension InProcessContext {
+    public func runtimePointer(at address: UnsafeRawPointer) throws -> UnsafeRawPointer? {
+        address
+    }
+}
+
+extension MachOContext {
+    public func runtimePointer(at address: Int) throws -> UnsafeRawPointer? {
+        if let machOImage = machO as? MachOImage {
+            return machOImage.ptr + UnsafeRawPointer.Stride(address)
+        }
+        return nil
+    }
+}
+```
+
+The runtime `as?` cast inside `MachOContext` is unavoidable because the
+generic parameter `MachO` is unconstrained at the type level; specializing
+the extension with `where MachO == MachOImage` would not produce a witness
+for the `MachOContext<MachOImage>: ReadingContext` conformance because the
+witness is bound at the unconstrained conformance site.
+
+`runtimePointer(at:)` is **not** added as a `requirement` of the
+`ReadingContext` protocol — adding it as an extension method with a default
+implementation keeps the change non-breaking for any external conformer.
+
+With this in place, runtime-pointer methods translate cleanly:
+
+```swift
+public func metadataAccessorFunction<Context: ReadingContext>(
+    in context: Context
+) throws -> MetadataAccessorFunction? {
+    let fieldAddress = try context.addressFromOffset(offset + layout.offset(of: .accessFunctionPtr))
+    let relativeOffset: Int32 = try context.readElement(at: fieldAddress)
+    let targetAddress = context.advanceAddress(fieldAddress, by: Int(relativeOffset))
+    return try context.runtimePointer(at: targetAddress).map { MetadataAccessorFunction(ptr: $0) }
+}
+```
+
+For `MachOContext<MachOFile>` this returns `nil`, matching today's MachO
+overload. For `InProcessContext` and `MachOContext<MachOImage>` it returns
+the function pointer, matching the InProcess overload's behavior.
+
+The implementation pass will identify the small set of similar
+runtime-pointer-returning methods (likely confined to a few metadata
+descriptors) and apply the same pattern.
+
+### 3. Files in scope
+
+The 45 files needing new overloads live in these sub-directories of
+`Sources/MachOSwiftSection/Models/`:
+
+- `Anonymous/`, `Module/`, `Extension/`
+- `ContextDescriptor/` (`ContextProtocol.swift`, `ContextWrapper.swift`)
+- `Type/Class/` (descriptor, methods, metadata protocols)
+- `Type/Enum/`, `Type/Struct/`
+- `Type/` root (`TypeContextDescriptor.swift`, `TypeContextWrapper.swift`,
+  `TypeReference.swift`, `ValueMetadataProtocol.swift`)
+- `Protocol/`, `ProtocolConformance/`
+- `Generic/` (`GenericRequirement.swift` — the descriptor already has it)
+- `FieldDescriptor/`, `FieldRecord/`, `AssociatedType/`
+- `Metadata/` (protocols and wrappers)
+- `ExistentialType/`, `ForeignType/`, `TupleType/`, `OpaqueType/`,
+  `BuiltinType/`
+
+The complete list is the output of:
+
+```sh
+grep -rL "ReadingContext" $(grep -rl "MachOSwiftSectionRepresentableWithCache" \
+  Sources/MachOSwiftSection/Models)
+```
+
+at the start of the implementation. The implementation plan will pin a
+verified file list per batch.
+
+### 4. Batch plan (commit grouping)
+
+Each batch is a single commit and must build cleanly (`swift build`) before
+moving on. Batches are grouped to keep diffs cohesive and reviewable:
+
+1. **Reading-context infrastructure** — add `runtimePointer(at:)` extension
+   in `MachOReading` (no model file changes yet).
+2. `Anonymous/`, `Module/`, `Extension/` (simple context wrappers).
+3. `ContextDescriptor/` (`ContextProtocol.swift`, `ContextWrapper.swift`).
+4. `Type/Class/*` (descriptor, methods, metadata protocols).
+5. `Type/Enum/*`, `Type/Struct/*`.
+6. `Type/` root files (descriptor, wrapper, references, metadata
+   protocols), including `metadataAccessorFunction` overload using
+   `runtimePointer(at:)`.
+7. `Protocol/`, `ProtocolConformance/`.
+8. `Generic/` (`GenericRequirement.swift`),
+   `FieldDescriptor/`, `FieldRecord/`, `AssociatedType/`.
+9. `Metadata/` (protocols, wrappers).
+10. `ExistentialType/`, `ForeignType/`, `TupleType/`, `OpaqueType/`,
+    `BuiltinType/`.
+
+If any batch turns out larger or smaller than expected, the plan can
+re-balance — the only invariant is "one batch = one passing build".
+
+## Validation
+
+- `swift package update && swift build` after each batch.
+- `swift test` once at the end of the work, to confirm the existing
+  `MachOSwiftSectionTests`, `SwiftDumpTests`, and `SwiftInterfaceTests`
+  suites still pass (they exercise the underlying MachO/InProcess paths
+  that the new overloads reduce to).
+- Spot check: pick one or two of the new overloads (e.g.
+  `TypeContextDescriptorProtocol.fieldDescriptor(in:)` once added) and
+  confirm they delegate to the same primitives as the existing MachO
+  overload by reading the diff.
+
+## Risks and mitigations
+
+- **Risk:** A method's MachO overload has subtle behavior (e.g. early
+  return on a bind/rebase resolver, special-case for `MachOImage`) that the
+  mechanical translation skips.
+  - *Mitigation:* During each batch, read the existing overload end-to-end
+    before mirroring it. Anything that does not fit the substitution table
+    above gets a per-method note in the commit message.
+- **Risk:** `runtimePointer(at:)` extension default returns `nil` and a
+  caller silently loses functionality for `MachOContext<MachOFile>`.
+  - *Mitigation:* This matches today's behavior — the existing
+    `metadataAccessorFunction(in: MachO)` already returns `nil` for
+    `MachOFile`. Documented explicitly on the extension.
+- **Risk:** A future contributor adds a new `ReadingContext` conformer and
+  expects `runtimePointer(at:)` to be a requirement.
+  - *Mitigation:* The doc comment on the extension states the contract;
+    making it an extension (not a requirement) is intentional to avoid a
+    breaking change.

--- a/docs/superpowers/specs/2026-05-03-machoswift-section-fixture-tests-design.md
+++ b/docs/superpowers/specs/2026-05-03-machoswift-section-fixture-tests-design.md
@@ -1,0 +1,550 @@
+# MachOSwiftSection Fixture-Based Test Coverage Design
+
+**日期:** 2026-05-03
+**状态:** 待实施
+**分支:** `feature/machoswift-section-fixture-tests`(待创建,从 `main` 拉)
+
+## 问题
+
+`Sources/MachOSwiftSection/Models/` 下有 **287 个 public func**、**781 个 public 成员**、分布于 **24 个子目录、约 60 个文件**。这些方法构成了把 Mach-O 二进制中 Swift 元数据节(`__swift5_types`、`__swift5_proto` 等)解析成 Swift 模型的全部入口。
+
+现状:
+
+- **`Tests/MachOSwiftSectionTests/`** 只有 9 个测试文件,大多 ad-hoc 风格,基于系统 framework(SwiftUI、dyld shared cache)而非可控 fixture,且没有"哪些方法被覆盖、哪些没被覆盖"的客观标准。
+- 最近刚加完的 ReadingContext API(每个 method 多了一个 `<Context: ReadingContext>(in: Context)` 重载)更需要回归保护——目前没有一个测试断言"三家 reader 在同一 fixture 上返回相同结果"。
+- `SwiftDumpTests` 已经建立了 fixture-based 范式(`SymbolTestsCoreDumpSnapshotTests` + `SymbolTestsCoreCoverageInvariantTests`),但守的是更高层 SwiftDump 输出,无法替代对 MachOSwiftSection reader API 直接的 ABI 级断言。
+
+本设计建立一套 fixture-based 测试体系,达成:
+
+- 每一个 `Sources/MachOSwiftSection/Models/**` 下的 public func/var/init **被至少一个 `@Test` 覆盖**;
+- 每个被覆盖方法做 **跨 reader 一致性断言**(MachOFile/MachOImage/InProcess + 三家对应 ReadingContext);
+- 每个被覆盖方法做 **完整 ABI 数值层硬编码断言**(offset、size、flags、count、name 等);
+- 新增 public method 不写测试 → `swift test` 红;
+- baseline 数据通过 generator 一次性生成、人工 review 后冻结进 git。
+
+## 目标
+
+1. 为 `Sources/MachOSwiftSection/Models/` 下所有 public 入口建立 fixture-based `@Test`,镜像源码目录结构。
+2. 引入 `MachOSwiftSectionFixtureTests` 基类,持有同一份 `SymbolTestsCore.framework` 的三种视图(`MachOFile`、`MachOImage`、`InProcessContext`)。
+3. 每个 `@Test` 同时执行**跨 reader 一致性断言**(三家 reader + 三家 ReadingContext)与**ABI baseline 字面量断言**。
+4. 提供 `baseline-generator` executable,从 fixture 自动生成 baseline 期望值,产出可读 Swift 代码,commit 进 git。
+5. 提供 `MachOSwiftSectionCoverageInvariantTests` 守护测试,基于源码静态扫描确保覆盖完整。
+6. 失败信息要 actionable,能直接告诉作者要新增/修改哪个 `@Test` 或 baseline。
+
+## 非目标
+
+- **扩展 fixture 内容**:`SymbolTestsCore.framework`(54 个 .swift 文件)已经覆盖大多数 Swift 语法元素,本期不增加新 fixture 文件。如某 model type 在 fixture 内找不到合适样本,先入 `CoverageAllowlist` 标 `needs fixture extension`,留 future work。
+- **测试 MachOSwiftSection 之外的模块**:SwiftDump/SwiftInspection/SwiftInterface/TypeIndexing 都已有(或不在范围)各自的测试套件,本期仅聚焦 `MachOSwiftSection`。
+- **性能 benchmark**:仅做正确性,不做性能基线。
+- **fixture 自动构建**:沿用 `xcodebuild -project Tests/Projects/SymbolTests/SymbolTests.xcodeproj -scheme SymbolTestsCore` 手动构建,DerivedData/ 已经 commit 在仓库内。
+- **重写或合并现有测试**:`LayoutTests`、`AssociatedTypeTests`、`MetadataAccessorTests` 等保留,作为补充,不冲突。
+
+## 设计
+
+### 1. 整体架构
+
+设计由四个支柱组成:
+
+```
+fixture.framework (SymbolTestsCore)
+        │
+        ├──[disk]──── MachOFile ──┐
+        ├──[dlopen]── MachOImage ─┼──→ 3 个 ReadingContext (file/image/inprocess) ──→ Tests
+        └──[ptr]───── InProcess ──┘
+                                       │
+                                       ├──→ ① cross-reader equality #expect (Suite 内自动)
+                                       └──→ ② ABI baseline literal #expect (引用 baseline)
+                                                       │
+                                                       └── BaselineGenerator 自动生成
+                                                                  ↑
+                                       MachOSwiftSectionCoverageInvariantTests 守护
+                                       ──→ 静态扫描 Sources/.../Models/ 找到 expected 名单
+                                       ──→ 反射 Suite registeredTestMethodNames 找到 registered 名单
+                                       ──→ missing/extra 必须为空
+```
+
+| 支柱 | 位置 | 职责 |
+|---|---|---|
+| Fixture 加载层 | `Sources/MachOTestingSupport/MachOSwiftSectionFixtureTests.swift` | 同时持有 fixture 的 MachOFile/MachOImage,以及三家 reader 与三家 ReadingContext |
+| Suite 层 | `Tests/MachOSwiftSectionTests/Fixtures/`(镜像 Models/ 24 子目录) | 50 个左右 Suite 文件,每个 `@Test` 对应一个 public method,做"跨 reader 一致性 + baseline 断言" |
+| Baseline Generator 层 | `Sources/MachOTestingSupport/Baseline/` + `Sources/baseline-generator/`(executable target) | 一次性运行,从 fixture 生成 `__Baseline__/<Suite>Baseline.swift` |
+| Coverage 守护层 | `Sources/MachOTestingSupport/Coverage/` + `Tests/MachOSwiftSectionTests/Fixtures/MachOSwiftSectionCoverageInvariantTests.swift` | 静态扫描源码 + 反射 Suite,缺漏直接红 |
+
+与现有测试的关系:
+
+- `LayoutTests.swift`(纯 Layout offset 计算)→ 保留,继续管 Layout。
+- `AssociatedTypeTests.swift` / `MetadataAccessorTests.swift` 等 ad-hoc 风格 → 保留,作为示例与补充。
+- `SwiftDumpTests/Snapshots/SymbolTestsCoreDumpSnapshotTests` → 不冲突,守的是 SwiftDump 输出,本套件守 MachOSwiftSection reader API。
+
+### 2. Test Infrastructure
+
+#### 2.1 `MachOSwiftSectionFixtureTests` 基类
+
+新文件 `Sources/MachOTestingSupport/MachOSwiftSectionFixtureTests.swift`:
+
+```swift
+@MainActor
+package class MachOSwiftSectionFixtureTests: Sendable {
+    package let machOFile: MachOFile
+    package let machOImage: MachOImage
+
+    package let fileContext: MachOContext<MachOFile>
+    package let imageContext: MachOContext<MachOImage>
+    package let inProcessContext: InProcessContext
+
+    package class var fixtureFileName: MachOFileName  { .SymbolTestsCore }
+    package class var fixtureImageName: MachOImageName { .SymbolTestsCore }
+
+    package init() async throws {
+        // 1. 磁盘加载(同 MachOFileTests)
+        let file = try loadFromFile(named: Self.fixtureFileName)
+        switch file {
+        case .fat(let fatFile):
+            self.machOFile = try required(
+                fatFile.machOFiles().first(where: { $0.header.cpuType == .arm64 })
+                    ?? fatFile.machOFiles().first
+            )
+        case .machO(let machO):
+            self.machOFile = machO
+        @unknown default:
+            fatalError()
+        }
+
+        // 2. dlopen 加载到当前进程
+        try Self.ensureFixtureLoaded()
+        self.machOImage = try #require(MachOImage(named: Self.fixtureImageName))
+
+        // 3. 三家 context
+        self.fileContext = MachOContext(machO: machOFile)
+        self.imageContext = MachOContext(machO: machOImage)
+        self.inProcessContext = InProcessContext()
+    }
+
+    private static let dlopenOnce: Void = {
+        // MachOImageName 的 raw value 是相对路径 "../../Tests/...",dlopen 需绝对路径。
+        // 用 #filePath 作为 anchor 解析为绝对路径(同 SwiftDumpTests 已有的解析逻辑)。
+        let path = resolveFixturePath(MachOImageName.SymbolTestsCore.rawValue)
+        _ = dlopen(path, RTLD_LAZY)
+    }()
+
+    private static func ensureFixtureLoaded() throws {
+        _ = dlopenOnce
+        guard MachOImage(named: .SymbolTestsCore) != nil else {
+            throw FixtureLoadError.imageNotFoundAfterDlopen(
+                path: MachOImageName.SymbolTestsCore.rawValue,
+                dlerror: String(cString: dlerror() ?? "")
+            )
+        }
+    }
+}
+
+package enum FixtureLoadError: Error {
+    case imageNotFoundAfterDlopen(path: String, dlerror: String)
+}
+```
+
+#### 2.2 `MachOImageName.SymbolTestsCore` 枚举条目
+
+需要新增,镜像 `MachOFileName.SymbolTestsCore` 的相对路径:
+
+```swift
+extension MachOImageName {
+    case SymbolTestsCore = "../../Tests/Projects/SymbolTests/DerivedData/SymbolTests/Build/Products/Release/SymbolTestsCore.framework/Versions/A/SymbolTestsCore"
+    case SymbolTests = "../../Tests/Projects/SymbolTests/DerivedData/SymbolTests/Build/Products/Release/SymbolTests.framework/Versions/A/SymbolTests"
+}
+```
+
+#### 2.3 `acrossAllReaders` helper
+
+为减少 `@Test` 内重复,提供:
+
+```swift
+extension MachOSwiftSectionFixtureTests {
+    /// 在 (machOFile, machOImage, inProcess) 三家上分别求值,断言相等,返回唯一值。
+    package func acrossAllReaders<T: Equatable>(
+        file: () throws -> T,
+        image: () throws -> T,
+        inProcess: () throws -> T
+    ) throws -> T { ... }
+
+    /// 在 (fileContext, imageContext, inProcessContext) 三家 ReadingContext 上分别求值,断言相等。
+    package func acrossAllContexts<T: Equatable>(
+        file: () throws -> T,
+        image: () throws -> T,
+        inProcess: () throws -> T
+    ) throws -> T { ... }
+}
+```
+
+dlopen 失败采取**抛错**而非 fatalError,让 `@Test` 显示 actionable 信息;`dlerror` 输出到错误。
+
+### 3. Suite 结构
+
+#### 3.1 文件组织
+
+镜像 `Sources/MachOSwiftSection/Models/`:
+
+```
+Tests/MachOSwiftSectionTests/Fixtures/
+├── Anonymous/
+│   ├── AnonymousContextDescriptorTests.swift
+│   └── AnonymousContextTests.swift
+├── AssociatedType/...
+├── BuiltinType/...
+├── ContextDescriptor/...
+├── ExistentialType/...
+├── Extension/...
+├── FieldDescriptor/...
+├── FieldRecord/...
+├── ForeignType/...
+├── Generic/...
+├── Metadata/...
+├── Module/...
+├── OpaqueType/...
+├── Protocol/...
+├── ProtocolConformance/...
+├── TupleType/...
+└── Type/
+    ├── TypeContextDescriptorTests.swift
+    ├── TypeContextWrapperTests.swift
+    ├── TypeReferenceTests.swift
+    ├── TypeContextDescriptorProtocolTests.swift
+    ├── ValueMetadataProtocolTests.swift
+    ├── Class/
+    │   ├── ClassTests.swift
+    │   ├── ClassDescriptorTests.swift
+    │   ├── AnyClassMetadataProtocolTests.swift
+    │   ├── ...
+    │   └── Method/...
+    ├── Enum/
+    │   ├── EnumTests.swift
+    │   ├── EnumMetadataProtocolTests.swift
+    │   └── MultiPayloadEnumDescriptorTests.swift
+    └── Struct/
+        ├── StructTests.swift
+        └── StructMetadataProtocolTests.swift
+```
+
+约 50 个 Suite 文件。
+
+#### 3.2 Suite 模板
+
+```swift
+@Suite
+final class StructDescriptorTests: MachOSwiftSectionFixtureTests, FixtureSuite, @unchecked Sendable {
+    static let testedTypeName = "StructDescriptor"
+    static let registeredTestMethodNames: Set<String> = [
+        "name",
+        "fields",
+        "genericContext",
+        "numberOfFields",
+        "fieldOffsetVectorOffset",
+        // ... generator 同步生成
+    ]
+
+    private func pickedStruct(in machO: some MachOSwiftSectionRepresentableWithCache) throws -> StructDescriptor {
+        try #require(
+            machO.swift.typeContextDescriptors.lazy
+                .compactMap(\.struct)
+                .first(where: { try $0.name(in: machO) == "Structs.StructTest" })
+        )
+    }
+
+    @Test func name() async throws {
+        let fileSubject = try pickedStruct(in: machOFile)
+        let imageSubject = try pickedStruct(in: machOImage)
+
+        let fromFile      = try fileSubject.name(in: machOFile)
+        let fromImage     = try imageSubject.name(in: machOImage)
+        let fromInProcess = try imageSubject.asPointerWrapper(in: machOImage).name()
+        let fromFileCtx   = try fileSubject.name(in: fileContext)
+        let fromImageCtx  = try imageSubject.name(in: imageContext)
+
+        // ① cross-reader 一致性
+        #expect(fromFile == fromImage)
+        #expect(fromFile == fromInProcess)
+        #expect(fromFile == fromFileCtx)
+        #expect(fromFile == fromImageCtx)
+
+        // ② ABI baseline literal
+        #expect(fromFile == StructDescriptorBaseline.structTest.name)
+    }
+
+    // ... 每个 public func/var/init 一个 @Test
+}
+```
+
+约定:
+
+- `@Suite final class XxxTests: MachOSwiftSectionFixtureTests, FixtureSuite, @unchecked Sendable`,文件名 = `<被测类型>Tests.swift`。
+- 每个 `@Test func` 名 = 被测 member 名。
+- 每个 `@Test` 同时做 ① cross-reader equality(包括 fileContext/imageContext/inProcessContext)和 ② baseline literal。
+- 跨 reader 比对 wrapper 类型时,投影到"语义可比较"字段(string、numeric、array of string),避免 wrapper 内部不可比较的 offset/pointer。
+- **InProcess 重载缺失**:并非每个 method 都有 `()` 形式的 InProcess 重载(部分 model 类型未提供 `asPointerWrapper`,或 InProcess 形式与 MachO 形式不对称)。Suite 模板对没有 InProcess 重载的 method 跳过 `fromInProcess` 一致性断言;对没有 ReadingContext 重载的 method(极少数)同理跳过 context 断言。每个 `@Test` 实际验证哪些 reader 由该 method 在源码中存在的重载决定,plan 阶段会逐 method 列出。
+
+#### 3.3 fixture 主测目标策略
+
+每个 Suite 选 **1 主 + 2~3 个反差变体**(由 `BaselineFixturePicker` 统一规划):
+
+- struct:Structs.StructTest(主) + GenericFieldLayout.GenericStructNonRequirement(generic)。
+- class:Classes.ClassTest(主) + DiamondInheritance.DiamondLeaf(继承链) + Classes.ObjCDerivedTest(ObjC interop)。
+- enum:Enums.EnumTest(主) + (single payload) + (multi-payload)。
+- protocol:Protocols.ProtocolTest(主) + AssociatedTypeWitnessPatterns 选 1 关联类型 protocol。
+- 等等。
+
+#### 3.4 Baseline 引用形态
+
+每个 Suite 配 `Tests/MachOSwiftSectionTests/Fixtures/__Baseline__/<Suite>Baseline.swift`:
+
+```swift
+// AUTO-GENERATED — DO NOT EDIT.
+// Regenerate via: swift run baseline-generator --suite StructDescriptor
+// Source fixture: SymbolTestsCore.framework
+// Toolchain: Swift 6.2 (swiftlang-6.2.x)
+// Generated: 2026-05-03
+
+enum StructDescriptorBaseline {
+    static let registeredTestMethodNames: Set<String> = [
+        "name", "fields", "genericContext",
+        "numberOfFields", "fieldOffsetVectorOffset",
+    ]
+
+    struct Entry {
+        let name: String
+        let numberOfFields: Int
+        let fieldNames: [String]
+        let fieldOffsets: [Int]
+        let isGeneric: Bool
+        let flagsRawValue: UInt32
+    }
+
+    static let structTest = Entry(
+        name: "SymbolTestsCore.Structs.StructTest",
+        numberOfFields: 1,
+        fieldNames: ["body"],
+        fieldOffsets: [0x10],
+        isGeneric: false,
+        flagsRawValue: 0x40000051
+    )
+
+    static let genericStructNonRequirement = Entry(
+        name: "SymbolTestsCore.GenericFieldLayout.GenericStructNonRequirement",
+        numberOfFields: 3,
+        fieldNames: ["field1", "field2", "field3"],
+        fieldOffsets: [0x10, 0x18, 0x28],
+        isGeneric: true,
+        flagsRawValue: 0x40000091
+    )
+}
+```
+
+### 4. Baseline Generator
+
+#### 4.1 形态
+
+独立 executable target `baseline-generator`,通过 `swift run baseline-generator [--suite <name>] [--output <dir>]` 触发。
+不混入 `swift test`(不属于"测试")。
+
+#### 4.2 模块组织
+
+```
+Sources/MachOTestingSupport/Baseline/
+├── BaselineGenerator.swift      // 主入口:遍历 fixture、调度子 generator
+├── BaselineEmitter.swift        // 数值 → Swift 字面量(offset/flags hex,count 十进制)
+├── BaselineFixturePicker.swift  // 在 fixture 中找"主测目标 + 关键变体"
+└── Generators/
+    ├── StructDescriptorBaselineGenerator.swift
+    ├── ClassDescriptorBaselineGenerator.swift
+    └── ... (每个被测 type 一个 generator)
+
+Sources/baseline-generator/
+└── main.swift                    // ArgumentParser + 调 BaselineGenerator
+```
+
+#### 4.3 生成流程
+
+```
+1. 加载 fixture(同 MachOSwiftSectionFixtureTests:磁盘 + dlopen)
+2. 对每个被测 model type
+   ├── BaselineFixturePicker 选出 (主测目标 + 关键变体)
+   ├── 对每个挑中的 fixture entity,Generator 调用 entity 上每个 public 入口
+   │   └── BaselineEmitter 序列化为 Swift 字面量
+   └── 输出 <Suite>Baseline.swift 到 Tests/MachOSwiftSectionTests/Fixtures/__Baseline__/
+3. 同时输出每个 Suite 的 registeredTestMethodNames(嵌入对应 `<Suite>Baseline.swift`)+ 一个汇总文件 `Tests/MachOSwiftSectionTests/Fixtures/__Baseline__/AllFixtureSuites.swift`,内含 `allFixtureSuites` 数组(供 Coverage 守护测试使用)
+4. 文件头写元数据:fixture commit hash + Swift toolchain version + 生成日期
+```
+
+#### 4.4 Emitter 数值进制约定
+
+- **offset / size** 用 hex(`0x10`),便于和 `otool`/Hopper 对照。
+- **flags rawValue** 用 hex(`0x40000051`),与 Swift 源码内 flag 定义一致。
+- **count / index** 用十进制。
+- **name / mangled name** 用字符串字面量,转义 backslash/quote。
+- **enum 值**(如 `ContextDescriptorKind`)输出全限定名:`.class`。
+
+#### 4.5 重生成流程(operator-facing)
+
+fixture 重编后(toolchain 升级 / 源文件改动):
+
+```
+1. xcodebuild -project Tests/Projects/SymbolTests/SymbolTests.xcodeproj \
+              -scheme SymbolTestsCore -configuration Release build
+2. swift run baseline-generator --output Tests/MachOSwiftSectionTests/Fixtures/__Baseline__
+3. git diff Tests/MachOSwiftSectionTests/Fixtures/__Baseline__
+   ── 漂移符合预期:commit
+   ── 漂移不符合预期:定位 reader bug
+4. swift test --filter MachOSwiftSectionTests
+```
+
+支持 `--suite <Name>` 局部重生,降低 review 范围。
+
+#### 4.6 Generator 自身正确性保证
+
+- generator 只用 **MachOFile** 路径生成 baseline(单一路径,易审)。
+- 测试 Suite 通过三家 reader 一致性独立验证 MachOImage/InProcess,**不依赖** baseline。
+- 关键 emitter(数值进制、字符串转义)有专门的 emitter unit test。
+
+### 5. Coverage Invariant
+
+#### 5.1 数据源
+
+- **expected**:SwiftSyntax 静态扫描 `Sources/MachOSwiftSection/Models/**/*.swift`,提取每个 `public func`/`public var`/`public init`。
+- **registered**:反射所有 `FixtureSuite`-conforming Suite 类型的 `static var registeredTestMethodNames` + `testedTypeName`。
+
+#### 5.2 MethodKey
+
+```swift
+struct MethodKey: Hashable, Comparable {
+    let typeName: String        // e.g. "StructDescriptor"
+    let memberName: String      // e.g. "fields"
+}
+```
+
+**重载合并**:三家重载(`(in: MachO)` / `(in: Context)` / `()` InProcess)共享一个 `memberName`,在单个 `@Test` 内验证一致性。Coverage 守护按 `(typeName, memberName)` 比对,不区分重载。
+
+#### 5.3 Scanner 实现
+
+`Sources/MachOTestingSupport/Coverage/PublicMemberScanner.swift`:
+
+- 用 SwiftSyntax 解析 `Sources/MachOSwiftSection/Models/**/*.swift`。
+- 跳过 `@_spi(Internals)` 标注的方法。
+- 跳过 `internal`/`private`/`fileprivate`(必须 `public` 或 `open`)。
+- 跳过 `Layout` 内字段(已被 `LayoutTests` 覆盖)。
+- 跳过 `@MemberwiseInit` 宏生成的 `init(layout:offset:)`(识别 attribute 或签名)。
+- 接受 `Tests/MachOSwiftSectionTests/Fixtures/CoverageAllowlist.swift` 配置,允许 (a) 已知不可测方法的明确豁免,(b) 暂未支持的 fixture 场景。每个 allowlist 项必须有 reason 注释。
+
+#### 5.4 Coverage Test
+
+```swift
+@Suite
+struct MachOSwiftSectionCoverageInvariantTests {
+    @Test func everyPublicMemberHasATest() async throws {
+        let scanner = PublicMemberScanner(sourceRoot: ... /* Sources/MachOSwiftSection/Models */)
+        let expected = try scanner.scan(applyingAllowlist: CoverageAllowlist.entries)
+
+        let registered = Set(
+            allFixtureSuites.flatMap { suite -> [MethodKey] in
+                suite.registeredTestMethodNames.map { name in
+                    MethodKey(typeName: suite.testedTypeName, memberName: name)
+                }
+            }
+        )
+
+        let missing = expected.subtracting(registered)
+        let extra = registered.subtracting(expected)
+
+        #expect(missing.isEmpty, "Missing tests for: \(missing.sorted())")
+        #expect(extra.isEmpty, "Tests registered for non-existent members: \(extra.sorted())")
+    }
+}
+```
+
+`allFixtureSuites` 由 generator 同步生成:
+
+```swift
+let allFixtureSuites: [any FixtureSuite.Type] = [
+    StructDescriptorTests.self,
+    ClassDescriptorTests.self,
+    ProtocolDescriptorTests.self,
+    // ...
+]
+```
+
+#### 5.5 失败信息
+
+```
+Missing tests for these public members of MachOSwiftSection/Models:
+  StructDescriptor.classGenericContext
+  ClassDescriptor.objCRuntimeName
+  ProtocolDescriptor.numAssociatedTypes
+
+Tip: add these names to the registeredTestMethodNames of the corresponding Suite,
+add a @Test per name, and run `swift run baseline-generator --suite <Name>`
+to populate baseline expected values.
+```
+
+#### 5.6 Coverage / Generator 协作矩阵
+
+| 触发场景 | 谁动了什么 | Coverage 守护行为 |
+|---|---|---|
+| 给 Models/ 加 public method | scanner expected 多一项 | 失败,提示新增 @Test |
+| 给 Suite 加 @Test + registeredTestMethodNames | registered 多一项 | 通过(前提是 expected 也有) |
+| 删 public method 但忘删 @Test | scanner expected 少一项 | 失败 with "extra" |
+| 改 method 名 | expected/registered 都变 | 失败 with both,作者跟着改 |
+| 重新生成 baseline | generator 自动同步 registered | 通过 |
+
+### 6. 测试范围与 Allowlist
+
+#### 6.1 入测范围
+
+- `Sources/MachOSwiftSection/Models/**/*.swift` 中所有 `public`/`open` 标注的 `func` / `var` / `init`(open 主要出现在 class 上)。
+- 三家重载(`(in: MachO)` / `(in: Context)` / `()` InProcess)在单个 `@Test` 内一并验证;实际存在的重载由源码决定,缺失的跳过(见 §3.2)。
+
+#### 6.2 显式 Exclusions(`CoverageAllowlist`)
+
+每项必须带 reason:
+
+1. `@MemberwiseInit` 宏生成的 `init(layout:offset:)` —— 自动产物,无业务逻辑。
+2. `Layout` 类型的 `static func offset(of:)` —— 已在 `LayoutTests` 覆盖。
+3. MachO-only 调试 helper(如 `ResilientWitness.implementationAddress(in: MachO) -> String`)—— 已在源码 doc comment 标注非数据读取。
+4. `@_spi(Internals)` 标注的 public —— SPI 不属于稳定 API。
+5. `Capture/` 等高度专用 wrapper(实施阶段 case-by-case 决定),fixture 不触发的暂入 allowlist with reason `needs fixture extension`。
+
+### 7. Risks & Mitigations
+
+| 风险 | 触发 | 缓解 |
+|---|---|---|
+| Fixture 路径在 CI 上找不到 | DerivedData 相对路径 / CI working dir 不同 | (a) 沿用 SwiftDumpTests 已跑通的相对路径;(b) `init` 失败给 actionable 信息(指出 `xcodebuild` 命令) |
+| dlopen fixture framework 失败 | framework 未编译 / iOS Simulator 路径不匹配 / sandbox | 抛 `FixtureLoadError.imageNotFoundAfterDlopen(path:dlerror:)`,所有子类的 `@Test` init 阶段就 fail |
+| Fixture 重编 → ABI 漂移 | toolchain 升级 / 源文件改动 / Xcode 升级 | (a) `git diff __Baseline__` 一目了然;(b) baseline 头记录 toolchain version + 日期;(c) `--suite <name>` 局部重生 |
+| Generator 自身 bug 把错值固化进 baseline | generator 调用 reader 错或 emitter 转义错 | (a) generator 只用 MachOFile 单一路径,易审;(b) 三家 reader 一致性独立验证 MachOImage/InProcess;(c) emitter unit test |
+| 跨 reader 一致性"假阳性通过":三家都错同一个 bug | 共享底层 helper 出 bug | baseline 数值断言独立兜底 |
+| `@MemberwiseInit` 签名变化 → scanner 误判 | 宏更新 | scanner 基于 `@MemberwiseInit` attribute 是否存在,而非签名形状;allowlist 兜底 |
+| Coverage 守护数据漂移成本 | 改方法名同时改两处 | 失败信息明确 missing/extra;正常工作流是 `改源码 → 跑 generator → commit`,registered 自动同步 |
+| InProcess 路径在 fixture 上不存在的 method | 部分 model 类型未提供 `asPointerWrapper` 桥接,InProcess 与 MachO 重载不完全对称 | Suite 模板对没有 InProcess 重载的 method 跳过 `fromInProcess` 一致性断言;每个 `@Test` 实际验证的 reader 集合由 method 在源码中存在的重载决定(详见 §3.2) |
+| 测试规模膨胀拖慢 swift test | 几百 `@Test`,每个 init 加载 fixture | (a) `dlopen` 用 `static let` 只跑一次;(b) MachOFile/MachOImage 单 init 成本不高(SwiftDumpTests 已验证);(c) 必要时 future work 引入 fixture cache |
+
+## Validation
+
+实施完成的验收 checklist:
+
+- [ ] `swift test --filter MachOSwiftSectionTests` 全绿。
+- [ ] `swift test --filter MachOSwiftSectionCoverageInvariantTests` 绿(missing/extra 均空)。
+- [ ] `swift run baseline-generator --suite <任一>` 应该幂等(刚生成完跑不修改任何 baseline 文件)。
+- [ ] 在 `Sources/MachOSwiftSection/Models/Type/Struct/StructDescriptor.swift` 临时加空 `public func dummyForCoverageProbe() {}`,coverage test 必须报 missing 含 `StructDescriptor.dummyForCoverageProbe`。回滚后重新绿。
+- [ ] 在某个 Suite 临时改一个 baseline 数值断言,运行该 Suite 必须报 #expect 失败,信息能定位到具体 method 名。
+- [ ] CI 上无需新增配置即可通过(fixture 已编译并 commit 在 DerivedData/)。
+
+## 实施分批(初步)
+
+详细 plan 由 writing-plans 阶段产出,初步切分参考:
+
+1. **基础设施**:`MachOImageName.SymbolTestsCore` + `MachOSwiftSectionFixtureTests` + `acrossAllReaders` helper + `FixtureLoadError`。
+2. **BaselineEmitter**:数值/字符串/数组/Optional/enum 字面量序列化 + emitter unit test。
+3. **PublicMemberScanner + CoverageAllowlist 框架**:scanner 实现 + 一个故意制造的 sample 验证 missing/extra 报错。
+4. **第一个 Suite(StructDescriptorTests + StructDescriptorBaselineGenerator)** 跑通端到端流程,锁定模板。
+5. 后续按 Models/ 子目录批量迁移,每批一个 commit:Anonymous/Module/Extension → ContextDescriptor → Type/Class → Type/Enum → Type/Struct → Type 根 → Protocol/ProtocolConformance → Generic → FieldDescriptor/FieldRecord/AssociatedType → Metadata → ExistentialType/TupleType/OpaqueType/BuiltinType/ForeignType → Capture(若需)。
+6. **`MachOSwiftSectionCoverageInvariantTests`** 上线,把所有上面批次串起来守护。
+7. **`baseline-generator` executable target** 收尾(整合所有 sub generator + ArgumentParser)。
+
+每批一个 commit 且必须 `swift build` + `swift test --filter MachOSwiftSectionTests` 全绿。


### PR DESCRIPTION
## Summary
- Wire ContextProtocol and ContextWrapper so ReadingContext flows through MachO descriptor reads
- Close ReadingContext gaps in partial files
- Note that ResilientWitness.implementationAddress is MachO-only
- Add fixture-based test coverage design notes

## Test plan
- [ ] swift test --filter MachOSwiftSectionTests
- [ ] swift test --filter SwiftDumpTests
- [ ] Verify ReadingContext flows correctly through both MachOFile and MachOImage paths