### PR TITLE
fix(tests): restore interface-style sugaring for fixture DemangleOptions

### DIFF
--- a/Sources/MachOFixtureSupport/DemangleOptions.swift
+++ b/Sources/MachOFixtureSupport/DemangleOptions.swift
@@ -3,5 +3,11 @@ import MachOSwiftSection
 import SwiftDump
 
 extension DemangleOptions {
-    package static let test: DemangleOptions = .default
+    /// Snapshot/baseline fixtures are recorded with interface-style printing:
+    /// optionals sugar to `T?`, arrays to `[T]`, etc. (`.interface` sets
+    /// `.synthesizeSugarOnTypes`, which `.default` does not). Keep this on
+    /// `.interface` so the recorded `SwiftDumpTests` snapshots stay sugared and
+    /// idiomatic — switching to `.default` desugars every optional/array in the
+    /// output and breaks the snapshot suite.
+    package static let test: DemangleOptions = .interface
 }


### PR DESCRIPTION
## Summary

Fixes the `SymbolTestsCoreDumpSnapshotTests` failures that have kept the macOS CI job red on `main` since 2026-06-12.

## Root cause

Commit cf79a7b (`chore(tests): retarget integration fixtures to iOS 18.5 SwiftUICore`) flipped `DemangleOptions.test` from `.interface` to `.default` as a side effect ("reset the fixture DemangleOptions back to .default"):

```diff
-    package static let test: DemangleOptions = .interface
+    package static let test: DemangleOptions = .default
```

`.interface` sets `.synthesizeSugarOnTypes`; `.default` does not. So every optional in the dump output desugared from `T?` to `Swift.Optional<T>` (arrays/sets/dictionaries likewise lost their sugar). Example from `errorTypesSnapshot`:

```diff
-    case withContext(message: Swift.String, code: Swift.Int, underlying: Swift.Error?)
+    case withContext(message: Swift.String, code: Swift.Int, underlying: Swift.Optional<Swift.Error>)
-    let errorDescription: Swift.String?
+    let errorDescription: Swift.Optional<Swift.String>
```

The committed `SwiftDumpTests` snapshots were recorded under `.interface` (sugared), so all 37 failing snapshot assertions in that suite broke at once.

## Fix

Restore `DemangleOptions.test = .interface` so the recorded snapshots stay sugared and idiomatic. The desugared `.default` form is less readable and was not accompanied by a snapshot regeneration, so this was an unintended regression rather than a deliberate output change.

The only other `.test` consumer in an asserted suite, `SpecializedDumperFieldTypeTests`, uses substring (`contains`) assertions that are insensitive to optional sugaring, so it is unaffected.

## Testing

Verified locally (`swift test`, macOS): **75/75** across every `.test` consumer —
- `SymbolTestsCoreDumpSnapshotTests` (59)
- `SpecializedDumperFieldTypeTests`
- `SymbolTestsCoreCoverageInvariantTests`