### PR TITLE
0.12.0-beta.5: SwiftInterface gutter diff polish + printer Rows fix

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -223,7 +223,7 @@ extension Package.Dependency {
         ),
         remote: .package(
             url: "https://github.com/MxIris-Reverse-Engineering/swift-semantic-string",
-            exact: "0.1.1",
+            from: "0.1.5",
         ),
     )
 }

--- a/Sources/MachOFixtureSupport/DyldSharedCachePath.swift
+++ b/Sources/MachOFixtureSupport/DyldSharedCachePath.swift
@@ -4,4 +4,6 @@ package enum DyldSharedCachePath: String {
     case iOS_18_5 = "/Volumes/Generic/iOS Systems/22F76__iPhone17,5/dyld_shared_cache_arm64e"
     case iOS_26_1 = "/Volumes/Generic/iOS Systems/23B85__iPhone17,5/dyld_shared_cache_arm64e"
     case issueCase = "/Users/JH/Downloads/19E241__iPhone11,2_4_6_iPhone12,3_5/dyld_shared_cache_arm64e"
+    case macOS_26_5_1 = "/Volumes/DyldSharedCaches/macOS/26.5.1_25F80/dyld_shared_cache_arm64e"
+    case macOS_27_0_beta_1 = "/Volumes/DyldSharedCaches/macOS/27.0-beta.1_26A5353q/dyld_shared_cache_arm64e"
 }

--- a/Sources/MachOTestingSupport/TestActor.swift
+++ b/Sources/MachOTestingSupport/TestActor.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+@globalActor
+public actor TestActor {
+    public static let shared = TestActor()
+}

--- a/Sources/SwiftInterface/DiffFormat.swift
+++ b/Sources/SwiftInterface/DiffFormat.swift
@@ -70,13 +70,14 @@ extension DiffFormat {
     }
 
     /// The default: git-diff-style line prefixes (`+` added, `-` removed, a space
-    /// for unchanged) at column 0, then the structural indentation, then the
-    /// content. Top-level blocks are separated by one bare blank line. This
-    /// reproduces the original annotated-interface output byte-for-byte: its
+    /// for unchanged) at column 0, then a one-space gutter so column 0 is reserved
+    /// for the marker and content always starts at column 2 (the marker column
+    /// never visually runs into the code), then the structural indentation, then
+    /// the content. Top-level blocks are separated by one bare blank line. The
     /// per-line rule is ``DiffMarking/inlineLineComponents``, shared with
     /// ``DiffMarking/markLines``.
     public static let inline: DiffFormat = .perLine(blockSeparator: "\n\n") { marker, content, indentLevel in
-        SemanticString(components: DiffMarking.inlineLineComponents(marker: marker, content: content, indentLevel: indentLevel))
+        SemanticString(components: DiffMarking.inlineLineComponents(marker: marker, content: content, indentLevel: indentLevel, gutter: DiffMarking.inlineGutter))
     }
 
     /// The ``inline`` body wrapped in a ```` ```diff ```` fenced code block, ready

--- a/Sources/SwiftInterface/DiffMarking.swift
+++ b/Sources/SwiftInterface/DiffMarking.swift
@@ -33,14 +33,24 @@ public struct DiffLine: Sendable {
 }
 
 enum DiffMarking {
+    /// A one-space gutter inserted between the marker and the structural indent
+    /// in the human-readable formats (``DiffFormat/inline`` and the
+    /// ``DiffFormat/markdownFenced`` body) so column 0 is dedicated to the
+    /// `+`/`-`/` ` marker and content always starts at column 2 — the marker
+    /// column never visually runs into the code. The real-unified-diff path
+    /// keeps its empty gutter so the output stays consumable by `git apply` /
+    /// `patch`.
+    static let inlineGutter = " "
+
     /// Prefixes every line of `source` with `marker` at column 0, followed by the
-    /// indentation for `indentLevel`, then the line's original content.
+    /// inline gutter, then the indentation for `indentLevel`, then the line's
+    /// original content.
     ///
     /// `source` is one rendered unit (a type header, a single member, a closing
     /// brace) with NO indentation and NO leading/trailing newline of its own —
-    /// the marker sits at column 0, git-diff style (`+    var x: Int`). Lines are
-    /// joined by `\n`; the result has no trailing newline so callers can join
-    /// units with `\n`.
+    /// the marker sits at column 0, followed by the gutter and the structural
+    /// indent (`+     var x: Int`). Lines are joined by `\n`; the result has no
+    /// trailing newline so callers can join units with `\n`.
     ///
     /// This is the eager, fully-marked form. It shares its per-line rule with
     /// ``inlineLineComponents`` — and therefore with ``DiffFormat/inline`` — so
@@ -56,7 +66,7 @@ enum DiffMarking {
             if lineIndex > 0 {
                 output.append(AtomicComponent(string: "\n", type: .standard))
             }
-            output.append(contentsOf: inlineLineComponents(marker: marker, content: SemanticString(components: line), indentLevel: indentLevel))
+            output.append(contentsOf: inlineLineComponents(marker: marker, content: SemanticString(components: line), indentLevel: indentLevel, gutter: inlineGutter))
         }
         return SemanticString(components: output)
     }
@@ -76,18 +86,21 @@ enum DiffMarking {
     }
 
     /// The atomic components of one git-diff-style line: the marker at column 0,
-    /// then the indentation for `indentLevel` (only on non-blank lines, so blank
-    /// lines carry no trailing whitespace after the marker), then the line's
-    /// content components (their semantic types preserved untouched).
+    /// then `gutter` (empty by default — used by the human-readable formats to
+    /// keep the marker column from visually eating into the code), then the
+    /// indentation for `indentLevel`, then the line's content components (their
+    /// semantic types preserved untouched). Neither the gutter nor the indent is
+    /// emitted on blank lines, so blank lines carry no trailing whitespace after
+    /// the marker.
     ///
     /// A line counts as blank when every content component is all-whitespace —
     /// the same rule the original `markLines` used, NOT `content.string.isEmpty`,
     /// so a line of pure spaces is still treated as blank.
-    static func inlineLineComponents(marker: DiffMarker, content: SemanticString, indentLevel: Int) -> [AtomicComponent] {
+    static func inlineLineComponents(marker: DiffMarker, content: SemanticString, indentLevel: Int, gutter: String = "") -> [AtomicComponent] {
         let contentComponents = content.components
         let lineHasContent = contentComponents.contains { !$0.string.allSatisfy(\.isWhitespace) }
         let indentation = String(repeating: " ", count: max(0, indentLevel) * 4)
-        var components: [AtomicComponent] = [AtomicComponent(string: marker.rawValue + (lineHasContent ? indentation : ""), type: .standard)]
+        var components: [AtomicComponent] = [AtomicComponent(string: marker.rawValue + (lineHasContent ? (gutter + indentation) : ""), type: .standard)]
         components.append(contentsOf: contentComponents)
         return components
     }

--- a/Sources/SwiftInterface/SwiftDiffableInterfaceRenderer.swift
+++ b/Sources/SwiftInterface/SwiftDiffableInterfaceRenderer.swift
@@ -24,7 +24,9 @@ import OrderedCollections
 /// `[[DiffLine]]` — and never bakes a diff symbol in. How a ``DiffMarker``
 /// becomes concrete output (git-diff prefixes, a unified-diff hunk, HTML, …) is
 /// the job of a ``DiffFormat``; ``printAnnotatedInterface(format:)`` defaults to
-/// ``DiffFormat/inline``, which reproduces the original git-diff output.
+/// ``DiffFormat/inline``, which emits the git-diff-style `+`/`-`/` ` line prefix
+/// at column 0 followed by a one-space gutter so column 0 is dedicated to the
+/// marker and content always starts at column 2.
 ///
 /// Surface is FULL: public, package, internal, and private declarations are all
 /// rendered (private discriminators kept). Access-level splitting is a future
@@ -52,9 +54,9 @@ public final class SwiftDiffableInterfaceRenderer<
     // MARK: - Top level
 
     /// Produces the annotated interface in the chosen ``DiffFormat`` (default
-    /// ``DiffFormat/inline``, which reproduces the original git-diff output). The
-    /// classified stream comes from ``annotatedDiffBlocks()``; the format turns it
-    /// into the final string.
+    /// ``DiffFormat/inline``, the git-diff-style `+`/`-`/` ` markers with a
+    /// one-space gutter). The classified stream comes from
+    /// ``annotatedDiffBlocks()``; the format turns it into the final string.
     public func printAnnotatedInterface(format: DiffFormat = .inline) async -> SemanticString {
         await format.render(annotatedDiffBlocks())
     }

--- a/Sources/SwiftPrinting/SwiftDeclarationPrinter.swift
+++ b/Sources/SwiftPrinting/SwiftDeclarationPrinter.swift
@@ -342,6 +342,12 @@ public final class SwiftDeclarationPrinter<MachO: FieldLayoutRenderable>: Sendab
     /// `byCategory` paths so the per-member comment layout has a single source of
     /// truth. The emit flags and comment prefix are hoisted by the caller (they
     /// depend on the enclosing definition, not the member).
+    ///
+    /// The body is wrapped in a `Rows(level: level) { ... }` so each comment
+    /// and the trailing declaration become independent rows at the enclosing
+    /// `MemberList`'s indent level. Returning a plain `SemanticString` without
+    /// `Rows` would fuse them into one row and drop the `BreakLine + Indent`
+    /// separators.
     @SemanticStringBuilder
     private func renderMember(
         _ member: OrderedMember,
@@ -352,28 +358,30 @@ public final class SwiftDeclarationPrinter<MachO: FieldLayoutRenderable>: Sendab
         printMemberAddress: Bool,
         vtableTransformerClosure: (@Sendable (Int, String?) -> SemanticString)?
     ) async -> SemanticString {
-        switch member {
-        case .allocator(let function), .function(let function):
-            OffsetComment(prefix: offsetCommentPrefix, offset: function.offset, emit: emitOffsetComment)
-            VTableOffsetComment(vtableOffset: function.vtableOffset, emit: printVTableOffset, transformer: vtableTransformerClosure)
-            AddressComment(addressString: memberAddressString(forOffset: function.symbol.offset), emit: printMemberAddress)
-            await printFunction(function, level: level)
+        await Rows(level: level) {
+            switch member {
+            case .allocator(let function), .function(let function):
+                OffsetComment(prefix: offsetCommentPrefix, offset: function.offset, emit: emitOffsetComment)
+                VTableOffsetComment(vtableOffset: function.vtableOffset, emit: printVTableOffset, transformer: vtableTransformerClosure)
+                AddressComment(addressString: memberAddressString(forOffset: function.symbol.offset), emit: printMemberAddress)
+                await printFunction(function, level: level)
 
-        case .variable(let variable):
-            OffsetComment(prefix: offsetCommentPrefix, offset: variable.offset, emit: emitOffsetComment)
-            for accessor in variable.accessors {
-                VTableOffsetComment(vtableOffset: accessor.vtableOffset, label: accessor.kind.addressLabel, emit: printVTableOffset, transformer: vtableTransformerClosure)
-                AddressComment(addressString: memberAddressString(forOffset: accessor.symbol.offset), label: accessor.kind.addressLabel, emit: printMemberAddress)
-            }
-            await printVariable(variable, level: level)
+            case .variable(let variable):
+                OffsetComment(prefix: offsetCommentPrefix, offset: variable.offset, emit: emitOffsetComment)
+                for accessor in variable.accessors {
+                    VTableOffsetComment(vtableOffset: accessor.vtableOffset, label: accessor.kind.addressLabel, emit: printVTableOffset, transformer: vtableTransformerClosure)
+                    AddressComment(addressString: memberAddressString(forOffset: accessor.symbol.offset), label: accessor.kind.addressLabel, emit: printMemberAddress)
+                }
+                await printVariable(variable, level: level)
 
-        case .subscript(let `subscript`):
-            OffsetComment(prefix: offsetCommentPrefix, offset: `subscript`.offset, emit: emitOffsetComment)
-            for accessor in `subscript`.accessors {
-                VTableOffsetComment(vtableOffset: accessor.vtableOffset, label: accessor.kind.addressLabel, emit: printVTableOffset, transformer: vtableTransformerClosure)
-                AddressComment(addressString: memberAddressString(forOffset: accessor.symbol.offset), label: accessor.kind.addressLabel, emit: printMemberAddress)
+            case .subscript(let `subscript`):
+                OffsetComment(prefix: offsetCommentPrefix, offset: `subscript`.offset, emit: emitOffsetComment)
+                for accessor in `subscript`.accessors {
+                    VTableOffsetComment(vtableOffset: accessor.vtableOffset, label: accessor.kind.addressLabel, emit: printVTableOffset, transformer: vtableTransformerClosure)
+                    AddressComment(addressString: memberAddressString(forOffset: accessor.symbol.offset), label: accessor.kind.addressLabel, emit: printMemberAddress)
+                }
+                await printSubscript(`subscript`, level: level)
             }
-            await printSubscript(`subscript`, level: level)
         }
     }
 

--- a/Sources/swift-section/Version.swift
+++ b/Sources/swift-section/Version.swift
@@ -2,5 +2,5 @@
 // When bumping: also add Changelogs/<value>.md, then tag the release with the same string.
 // Verified by .github/workflows/version-check.yml (PR) and .github/workflows/release.yml (tag).
 enum BundledVersion {
-    static let value = "0.12.0-beta.4"
+    static let value = "0.12.0-beta.6"
 }

--- a/Tests/IntegrationTests/SwiftInspection/MultiPayloadEnumTests.swift
+++ b/Tests/IntegrationTests/SwiftInspection/MultiPayloadEnumTests.swift
@@ -12,9 +12,8 @@ import MachOFixtureSupport
 import SwiftUI
 
 final class MultiPayloadEnumTests: MachOImageTests {
-    
     typealias Calculator = EnumLayoutCalculator
-    
+
     override class var imageName: MachOImageName { .SwiftUICore }
 
     private var multiPayloadEnumDescriptorByMangledName: [String: MultiPayloadEnumDescriptor] = [:]
@@ -65,25 +64,20 @@ final class MultiPayloadEnumTests: MachOImageTests {
             var optionalSize = 0
             let enumTypeLayout = try enumMetadata.asFullMetadata().valueWitnesses.resolve().typeLayout
             defer {
-                do {
-                    if enumDescriptor.isMultiPayload {
-                        if let multiPayloadEnumDescriptor = multiPayloadEnumDescriptorByMangledName[typeName], multiPayloadEnumDescriptor.usesPayloadSpareBits {
-                            try printMultiPayloadEnum(multiPayloadEnumDescriptor)
-                            let spareBytes = try multiPayloadEnumDescriptor.payloadSpareBits()
-                            let spareBytesOffset = try multiPayloadEnumDescriptor.payloadSpareBitMaskByteOffset()
-                            Calculator.calculateMultiPayload( /* enumSize: enumTypeLayout.size.cast(), */ payloadSize: payloadSize.cast(), spareBytes: spareBytes, spareBytesOffset: spareBytesOffset.cast(), numPayloadCases: payloadCases.cast(), numEmptyCases: emptyCases.cast()).print()
-                            if optionalSize > .zero {
-                                Calculator.calculateSinglePayload(size: optionalSize, payloadSize: payloadSize.cast(), numEmptyCases: 1, spareBytes: spareBytes, spareBytesOffset: spareBytesOffset.cast()).print()
-                            }
-                        } else {
-                            Calculator.calculateTaggedMultiPayload(payloadSize: payloadSize.cast(), numPayloadCases: payloadCases.cast(), numEmptyCases: emptyCases.cast()).print()
+                if enumDescriptor.isMultiPayload {
+                    if let multiPayloadEnumDescriptor = multiPayloadEnumDescriptorByMangledName[typeName], multiPayloadEnumDescriptor.usesPayloadSpareBits,
+                        let spareBytes = try? multiPayloadEnumDescriptor.payloadSpareBits(),
+                        let spareBytesOffset = try? multiPayloadEnumDescriptor.payloadSpareBitMaskByteOffset() {
+                        try? printMultiPayloadEnum(multiPayloadEnumDescriptor)
+                        Calculator.calculateMultiPayload( /* enumSize: enumTypeLayout.size.cast(), */ payloadSize: payloadSize.cast(), spareBytes: spareBytes, spareBytesOffset: spareBytesOffset.cast(), numPayloadCases: payloadCases.cast(), numEmptyCases: emptyCases.cast()).print()
+                        if optionalSize > .zero {
+                            Calculator.calculateSinglePayload(size: optionalSize, payloadSize: payloadSize.cast(), numEmptyCases: 1, spareBytes: spareBytes, spareBytesOffset: spareBytesOffset.cast()).print()
                         }
-                    } else if enumDescriptor.isSinglePayload {
-                        Calculator.calculateSinglePayload(size: enumTypeLayout.size.cast(), payloadSize: payloadSize.cast(), numEmptyCases: emptyCases.cast()).print()
+                    } else {
+                        Calculator.calculateTaggedMultiPayload(payloadSize: payloadSize.cast(), numPayloadCases: payloadCases.cast(), numEmptyCases: emptyCases.cast()).print()
                     }
-
-                } catch {
-                    print(error)
+                } else if enumDescriptor.isSinglePayload {
+                    Calculator.calculateSinglePayload(size: enumTypeLayout.size.cast(), payloadSize: payloadSize.cast(), numEmptyCases: emptyCases.cast()).print()
                 }
                 print("---------------------")
             }
@@ -121,7 +115,7 @@ final class MultiPayloadEnumTests: MachOImageTests {
                 let mangledTypeNameString = try await mangleAsString(node)
                 if let metatype = try RuntimeFunctions.getTypeByMangledNameInContext(mangledTypeName, genericContext: nil, genericArguments: nil) {
                     let currentMetadata = try Metadata.createInProcess(metatype)
-                    try print("\(indirectCaseString)case \(record.fieldName())\(payloadString("\(await node.print(using: .interfaceTypeBuilderOnly))"))")
+                    try await print("\(indirectCaseString)case \(record.fieldName())\(payloadString("\(node.print(using: .interfaceTypeBuilderOnly))"))")
                     let metadataWrapper = try currentMetadata.asMetadataWrapper()
                     let typeLayout = try currentMetadata.asFullMetadata().valueWitnesses.resolve().typeLayout
                     let indentLevel = 1

--- a/Tests/IntegrationTests/SwiftInterface/SwiftDiffableInterfaceBuilderTests.swift
+++ b/Tests/IntegrationTests/SwiftInterface/SwiftDiffableInterfaceBuilderTests.swift
@@ -4,6 +4,7 @@ import SwiftDeclarationRendering
 import MachOKit
 import MachOExtensions
 import MachOFixtureSupport
+import MachOTestingSupport
 @testable import MachOSwiftSection
 @testable import SwiftInterface
 @_spi(Support) @testable import SwiftIndexing
@@ -30,7 +31,7 @@ extension SwiftDiffableInterfaceBuilderTests {
     /// covers the whole preparation.
     private func preparedBuilders<Old: FieldLayoutRenderable, New: FieldLayoutRenderable>(
         old: Old,
-        new: New
+        new: New,
     ) async throws -> (old: SwiftDiffableInterfaceBuilder<Old>, new: SwiftDiffableInterfaceBuilder<New>) {
         let oldBuilder = SwiftDiffableInterfaceBuilder(configuration: indexConfiguration, in: old)
         let newBuilder = SwiftDiffableInterfaceBuilder(configuration: indexConfiguration, in: new)
@@ -45,7 +46,7 @@ extension SwiftDiffableInterfaceBuilderTests {
     /// mirroring `swift-section diff`'s text report.
     private func changeListReport<Old: FieldLayoutRenderable, New: FieldLayoutRenderable>(
         old: SwiftDiffableInterfaceBuilder<Old>,
-        new: SwiftDiffableInterfaceBuilder<New>
+        new: SwiftDiffableInterfaceBuilder<New>,
     ) -> String {
         let diff = ABIDiffer().diff(old: old.abiModule(), new: new.abiModule())
         let verdict = "ABI-breaking: \(diff.hasBreakingChange) · backward-compatible: \(diff.isBackwardCompatible)"
@@ -56,20 +57,21 @@ extension SwiftDiffableInterfaceBuilderTests {
     /// `swift-section diff --interface`.
     private func annotatedInterface<Old: FieldLayoutRenderable, New: FieldLayoutRenderable>(
         old: SwiftDiffableInterfaceBuilder<Old>,
-        new: SwiftDiffableInterfaceBuilder<New>
+        new: SwiftDiffableInterfaceBuilder<New>,
+        format: DiffFormat = .inline,
     ) async -> String {
-        await SwiftDiffableInterfaceRenderer(old: old, new: new).printAnnotatedInterface().string
+        await SwiftDiffableInterfaceRenderer(old: old, new: new).printAnnotatedInterface(format: format).string
     }
 
     /// Console analogue of `buildString`: prepares both binaries, then prints the
     /// change list and the annotated interface.
     func diffString<Old: FieldLayoutRenderable, New: FieldLayoutRenderable>(
         old: Old,
-        new: New
+        new: New,
     ) async throws {
         let (oldBuilder, newBuilder) = try await preparedBuilders(old: old, new: new)
         printResult(changeListReport(old: oldBuilder, new: newBuilder))
-        printResult(await annotatedInterface(old: oldBuilder, new: newBuilder))
+        await printResult(annotatedInterface(old: oldBuilder, new: newBuilder))
     }
 
     /// File analogue of `buildFile`: writes the change list (`-Diff.txt`) and the
@@ -77,11 +79,12 @@ extension SwiftDiffableInterfaceBuilderTests {
     /// single-binary interface dumps, both named after the *new* binary.
     func diffFile<Old: FieldLayoutRenderable, New: FieldLayoutRenderable>(
         old: Old,
-        new: New
+        new: New,
     ) async throws {
         let (oldBuilder, newBuilder) = try await preparedBuilders(old: old, new: new)
         try write(changeListReport(old: oldBuilder, new: newBuilder), for: newBuilder.machO, suffix: "Diff", fileExtension: "txt")
-        try write(await annotatedInterface(old: oldBuilder, new: newBuilder), for: newBuilder.machO, suffix: "AnnotatedInterface")
+        try await write(annotatedInterface(old: oldBuilder, new: newBuilder, format: .inline), for: newBuilder.machO, suffix: "AnnotatedInterface-Inline")
+        try await write(annotatedInterface(old: oldBuilder, new: newBuilder, format: .unified()), for: newBuilder.machO, suffix: "AnnotatedInterface-Unified")
     }
 }
 
@@ -100,94 +103,93 @@ private func selectMachOFile(from file: File, architecture: CPUType) throws -> M
     }
 }
 
-/// Loads a fixed `(old, new)` pair of `MachOFile`s by name — the two-binary
-/// counterpart of `MachOTestingSupport.MachOFileTests`, which only loads one.
-@MainActor
-class CrossVersionMachOFileTests: Sendable {
-    let oldMachOFile: MachOFile
-    let newMachOFile: MachOFile
-
-    class var oldFileName: MachOFileName { .iOS_18_5_Simulator_SwiftUICore }
-    class var newFileName: MachOFileName { .iOS_26_5_Simulator_SwiftUICore }
-    class var preferredArchitecture: CPUType { .arm64 }
-
-    init() async throws {
-        self.oldMachOFile = try selectMachOFile(from: try loadFromFile(named: Self.oldFileName), architecture: Self.preferredArchitecture)
-        self.newMachOFile = try selectMachOFile(from: try loadFromFile(named: Self.newFileName), architecture: Self.preferredArchitecture)
-    }
-}
-
-/// Extracts the same image from two dyld shared caches — the two-binary,
-/// two-cache counterpart of `MachOTestingSupport.DyldCacheTests`. The caches are
-/// retained because the extracted `MachOFile`s resolve cross-image references
-/// (into Foundation, libswiftCore, …) through them while indexing.
-@MainActor
-class CrossVersionDyldCacheImageTests: Sendable {
-    let oldCache: DyldCache
-    let newCache: DyldCache
-    let oldMachOFileInCache: MachOFile
-    let newMachOFileInCache: MachOFile
-
-    class var oldCachePath: DyldSharedCachePath { .macOS_15_5 }
-    class var newCachePath: DyldSharedCachePath { .current }
-    class var cacheImageName: MachOImageName { .SwiftUI }
-
-    init() async throws {
-        let oldCache = try DyldCache(path: Self.oldCachePath)
-        let newCache = try DyldCache(path: Self.newCachePath)
-        self.oldCache = oldCache
-        self.newCache = newCache
-        self.oldMachOFileInCache = try #require(oldCache.machOFile(named: Self.cacheImageName))
-        self.newMachOFileInCache = try #require(newCache.machOFile(named: Self.cacheImageName))
-    }
-}
-
-/// Loads the same shared framework from two installed Xcode applications. The
-/// shared `XcodeMachOFileName` fixture hardcodes a single Xcode, so this loads
-/// by path directly — the local-loading counterpart that lets the diff compare
-/// two Xcode versions without changing the fixture.
-@MainActor
-class CrossVersionXcodeFrameworkTests: Sendable {
-    let oldMachOFile: MachOFile
-    let newMachOFile: MachOFile
-
-    class var oldXcodeApplicationPath: String { "/Applications/Xcode-26.3.0.app" }
-    class var newXcodeApplicationPath: String { "/Applications/Xcode-26.4.0.app" }
-    class var sharedFrameworkName: String { "DVTProductsUI" }
-    class var preferredArchitecture: CPUType { .arm64 }
-
-    init() async throws {
-        self.oldMachOFile = try Self.loadSharedFramework(inXcodeAt: Self.oldXcodeApplicationPath)
-        self.newMachOFile = try Self.loadSharedFramework(inXcodeAt: Self.newXcodeApplicationPath)
-    }
-
-    private class func loadSharedFramework(inXcodeAt xcodeApplicationPath: String) throws -> MachOFile {
-        let name = sharedFrameworkName
-        let binaryPath = "\(xcodeApplicationPath)/Contents/SharedFrameworks/\(name).framework/Versions/A/\(name)"
-        return try selectMachOFile(from: try File.loadFromFile(url: URL(fileURLWithPath: binaryPath)), architecture: preferredArchitecture)
-    }
-}
-
-@Suite
 enum SwiftDiffableInterfaceBuilderTestSuite {
+    /// Loads a fixed `(old, new)` pair of `MachOFile`s by name — the two-binary
+    /// counterpart of `MachOTestingSupport.MachOFileTests`, which only loads one.
+    @TestActor
+    class CrossVersionMachOFileTests: Sendable {
+        let oldMachOFile: MachOFile
+        let newMachOFile: MachOFile
+
+        class var oldFileName: MachOFileName { .iOS_18_5_Simulator_SwiftUICore }
+        class var newFileName: MachOFileName { .iOS_26_5_Simulator_SwiftUICore }
+        class var preferredArchitecture: CPUType { .arm64 }
+
+        init() async throws {
+            self.oldMachOFile = try selectMachOFile(from: loadFromFile(named: Self.oldFileName), architecture: Self.preferredArchitecture)
+            self.newMachOFile = try selectMachOFile(from: loadFromFile(named: Self.newFileName), architecture: Self.preferredArchitecture)
+        }
+    }
+
+    /// Extracts the same image from two dyld shared caches — the two-binary,
+    /// two-cache counterpart of `MachOTestingSupport.DyldCacheTests`. The caches are
+    /// retained because the extracted `MachOFile`s resolve cross-image references
+    /// (into Foundation, libswiftCore, …) through them while indexing.
+    @TestActor
+    class CrossVersionDyldCacheImageTests: Sendable {
+        let oldCache: DyldCache
+        let newCache: DyldCache
+        let oldMachOFileInCache: MachOFile
+        let newMachOFileInCache: MachOFile
+
+        class var oldCachePath: DyldSharedCachePath { .macOS_26_5_1 }
+        class var newCachePath: DyldSharedCachePath { .macOS_27_0_beta_1 }
+        class var cacheImageName: MachOImageName { .AppKit }
+
+        init() async throws {
+            let oldCache = try DyldCache(path: Self.oldCachePath)
+            let newCache = try DyldCache(path: Self.newCachePath)
+            self.oldCache = oldCache
+            self.newCache = newCache
+            self.oldMachOFileInCache = try #require(oldCache.machOFile(named: Self.cacheImageName))
+            self.newMachOFileInCache = try #require(newCache.machOFile(named: Self.cacheImageName))
+        }
+    }
+
+    /// Loads the same shared framework from two installed Xcode applications. The
+    /// shared `XcodeMachOFileName` fixture hardcodes a single Xcode, so this loads
+    /// by path directly — the local-loading counterpart that lets the diff compare
+    /// two Xcode versions without changing the fixture.
+    @TestActor
+    class CrossVersionXcodeFrameworkTests: Sendable {
+        let oldMachOFile: MachOFile
+        let newMachOFile: MachOFile
+
+        class var oldXcodeApplicationPath: String { "/Applications/Xcode-26.3.0.app" }
+        class var newXcodeApplicationPath: String { "/Applications/Xcode-26.4.0.app" }
+        class var sharedFrameworkName: String { "DVTProductsUI" }
+        class var preferredArchitecture: CPUType { .arm64 }
+
+        init() async throws {
+            self.oldMachOFile = try Self.loadSharedFramework(inXcodeAt: Self.oldXcodeApplicationPath)
+            self.newMachOFile = try Self.loadSharedFramework(inXcodeAt: Self.newXcodeApplicationPath)
+        }
+
+        private class func loadSharedFramework(inXcodeAt xcodeApplicationPath: String) throws -> MachOFile {
+            let name = sharedFrameworkName
+            let binaryPath = "\(xcodeApplicationPath)/Contents/SharedFrameworks/\(name).framework/Versions/A/\(name)"
+            return try selectMachOFile(from: File.loadFromFile(url: URL(fileURLWithPath: binaryPath)), architecture: preferredArchitecture)
+        }
+    }
+
     /// SwiftUICore across two simulator runtimes (iOS 18.5 → 26.2).
-    class SwiftUICoreTests: CrossVersionMachOFileTests, SwiftDiffableInterfaceBuilderTests, @unchecked Sendable {
+    final class SwiftUICoreTests: CrossVersionMachOFileTests, SwiftDiffableInterfaceBuilderTests, @unchecked Sendable {
         override class var oldFileName: MachOFileName { .iOS_18_5_Simulator_SwiftUICore }
         override class var newFileName: MachOFileName { .iOS_26_5_Simulator_SwiftUICore }
 
         @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
-        @Test func diffFile() async throws {
+        @Test func `diff file`() async throws {
             try await diffFile(old: oldMachOFile, new: newMachOFile)
         }
 
         @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
-        @Test func diffString() async throws {
+        @Test func `diff string`() async throws {
             try await diffString(old: oldMachOFile, new: newMachOFile)
         }
     }
 
     /// SwiftUI across two simulator runtimes (iOS 18.5 → 26.2).
-    class SwiftUITests: CrossVersionMachOFileTests, SwiftDiffableInterfaceBuilderTests, @unchecked Sendable {
+    final class SwiftUITests: CrossVersionMachOFileTests, SwiftDiffableInterfaceBuilderTests, @unchecked Sendable {
         override class var oldFileName: MachOFileName { .iOS_18_5_Simulator_SwiftUI }
         override class var newFileName: MachOFileName { .iOS_26_5_Simulator_SwiftUI }
 
@@ -201,12 +203,13 @@ enum SwiftDiffableInterfaceBuilderTestSuite {
             try await diffString(old: oldMachOFile, new: newMachOFile)
         }
     }
+
     /// The same macOS image (SwiftUI) extracted from two dyld shared caches
     /// (macOS 15.5 → current). Cross-image references resolve through each cache.
-    class DyldCacheTests: CrossVersionDyldCacheImageTests, SwiftDiffableInterfaceBuilderTests, @unchecked Sendable {
-        override class var oldCachePath: DyldSharedCachePath { .macOS_15_5 }
-        override class var newCachePath: DyldSharedCachePath { .current }
-        override class var cacheImageName: MachOImageName { .SwiftUI }
+    final class DyldCacheTests: CrossVersionDyldCacheImageTests, SwiftDiffableInterfaceBuilderTests, @unchecked Sendable {
+        override class var oldCachePath: DyldSharedCachePath { .macOS_26_5_1 }
+        override class var newCachePath: DyldSharedCachePath { .macOS_27_0_beta_1 }
+        override class var cacheImageName: MachOImageName { .AppKit }
 
         @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
         @Test func diffFile() async throws {
@@ -222,7 +225,7 @@ enum SwiftDiffableInterfaceBuilderTestSuite {
     /// The DVTProductsUI shared framework across two installed Xcode versions
     /// (26.3 → 26.4) — mirrors the framework the interface builder tests use,
     /// loaded by path so the diff can compare two Xcodes.
-    class XcodeFrameworkTests: CrossVersionXcodeFrameworkTests, SwiftDiffableInterfaceBuilderTests, @unchecked Sendable {
+    final class XcodeFrameworkTests: CrossVersionXcodeFrameworkTests, SwiftDiffableInterfaceBuilderTests, @unchecked Sendable {
         override class var oldXcodeApplicationPath: String { "/Applications/Xcode-26.3.0.app" }
         override class var newXcodeApplicationPath: String { "/Applications/Xcode-26.4.0.app" }
         override class var sharedFrameworkName: String { "DVTProductsUI" }

--- a/Tests/SwiftInterfaceTests/DiffContainerAssemblerTests.swift
+++ b/Tests/SwiftInterfaceTests/DiffContainerAssemblerTests.swift
@@ -13,7 +13,7 @@ struct DiffContainerAssemblerTests {
         let lines = DiffContainerAssembler.assemble(oldHeader: "", newHeader: "struct Foo", marker: .added, bodyUnits: [], level: 1)
         #expect(lines.count == 1)
         #expect(lines[0].marker == .added)
-        #expect(DiffFormat.inline.render([lines]).string == "+struct Foo {}")
+        #expect(DiffFormat.inline.render([lines]).string == "+ struct Foo {}")
     }
 
     @Test("a non-empty body opens with ` {`, carries body units, and closes with `}`")
@@ -21,7 +21,7 @@ struct DiffContainerAssemblerTests {
         let bodyLine = DiffLine(marker: .added, content: "var x: Int", indentLevel: 1)
         let lines = DiffContainerAssembler.assemble(oldHeader: "struct Foo", newHeader: "struct Foo", marker: .unchanged, bodyUnits: [[bodyLine]], level: 1)
         #expect(lines.map(\.marker) == [.unchanged, .added, .unchanged])
-        #expect(DiffFormat.inline.render([lines]).string == " struct Foo {\n+    var x: Int\n }")
+        #expect(DiffFormat.inline.render([lines]).string == "  struct Foo {\n+     var x: Int\n  }")
     }
 
     @Test("an added container marks every line `+` using the new header")
@@ -29,7 +29,7 @@ struct DiffContainerAssemblerTests {
         let bodyLine = DiffLine(marker: .added, content: "var x: Int", indentLevel: 1)
         let lines = DiffContainerAssembler.assemble(oldHeader: "", newHeader: "struct Foo", marker: .added, bodyUnits: [[bodyLine]], level: 1)
         #expect(lines.allSatisfy { $0.marker == .added })
-        #expect(DiffFormat.inline.render([lines]).string == "+struct Foo {\n+    var x: Int\n+}")
+        #expect(DiffFormat.inline.render([lines]).string == "+ struct Foo {\n+     var x: Int\n+ }")
     }
 
     @Test("a removed container marks every line `-` using the old header")
@@ -37,7 +37,7 @@ struct DiffContainerAssemblerTests {
         let bodyLine = DiffLine(marker: .removed, content: "var x: Int", indentLevel: 1)
         let lines = DiffContainerAssembler.assemble(oldHeader: "struct Foo", newHeader: "", marker: .removed, bodyUnits: [[bodyLine]], level: 1)
         #expect(lines.allSatisfy { $0.marker == .removed })
-        #expect(DiffFormat.inline.render([lines]).string == "-struct Foo {\n-    var x: Int\n-}")
+        #expect(DiffFormat.inline.render([lines]).string == "- struct Foo {\n-     var x: Int\n- }")
     }
 
     @Test("a changed header on a common container shows old `-` then new `+`, brace unchanged")
@@ -45,13 +45,14 @@ struct DiffContainerAssemblerTests {
         let bodyLine = DiffLine(marker: .unchanged, content: "var x: Int", indentLevel: 1)
         let lines = DiffContainerAssembler.assemble(oldHeader: "struct Foo: A", newHeader: "struct Foo: B", marker: .unchanged, bodyUnits: [[bodyLine]], level: 1)
         #expect(lines.map(\.marker) == [.removed, .added, .unchanged, .unchanged])
-        #expect(DiffFormat.inline.render([lines]).string == "-struct Foo: A {\n+struct Foo: B {\n     var x: Int\n }")
+        #expect(DiffFormat.inline.render([lines]).string == "- struct Foo: A {\n+ struct Foo: B {\n      var x: Int\n  }")
     }
 
     @Test("nested-level indentation places the marker at column 0 and indents the header after it")
     func nestedLevelIndentation() {
-        // A nested type at level 2: headerLevel 1 => 4-space indent after the marker.
+        // A nested type at level 2: headerLevel 1 => 1-space gutter + 4-space
+        // level indent => 5-space prefix between the marker and the header.
         let lines = DiffContainerAssembler.assemble(oldHeader: "", newHeader: "struct Inner", marker: .added, bodyUnits: [], level: 2)
-        #expect(DiffFormat.inline.render([lines]).string == "+    struct Inner {}")
+        #expect(DiffFormat.inline.render([lines]).string == "+     struct Inner {}")
     }
 }

--- a/Tests/SwiftInterfaceTests/DiffFormatTests.swift
+++ b/Tests/SwiftInterfaceTests/DiffFormatTests.swift
@@ -9,10 +9,10 @@ private func line(_ marker: DiffMarker, _ content: SemanticString, indent: Int =
 
 @Suite("DiffFormat.inline")
 struct DiffFormatInlineTests {
-    @Test("a single line is marker + level indent + content at column 0")
+    @Test("a single line is marker + one-space gutter + level indent + content at column 0")
     func singleLine() {
         let blocks = [[line(.added, "var x: Int", indent: 1)]]
-        #expect(DiffFormat.inline.render(blocks).string == "+    var x: Int")
+        #expect(DiffFormat.inline.render(blocks).string == "+     var x: Int")
     }
 
     @Test("lines within a block are joined by a single newline")
@@ -22,7 +22,7 @@ struct DiffFormatInlineTests {
             line(.added, "var x: Int", indent: 1),
             line(.unchanged, "}", indent: 0),
         ]]
-        #expect(DiffFormat.inline.render(blocks).string == " struct A {\n+    var x: Int\n }")
+        #expect(DiffFormat.inline.render(blocks).string == "  struct A {\n+     var x: Int\n  }")
     }
 
     @Test("top-level blocks are separated by exactly one bare blank line")
@@ -31,32 +31,33 @@ struct DiffFormatInlineTests {
             [line(.unchanged, "struct A {", indent: 0), line(.unchanged, "}", indent: 0)],
             [line(.removed, "func gone()", indent: 0)],
         ]
-        #expect(DiffFormat.inline.render(blocks).string == " struct A {\n }\n\n-func gone()")
+        #expect(DiffFormat.inline.render(blocks).string == "  struct A {\n  }\n\n- func gone()")
     }
 
-    @Test("a blank interior line carries only the marker, no trailing indent")
+    @Test("a blank interior line carries only the marker, no trailing gutter or indent")
     func blankInteriorLine() {
         let blocks = [[
             line(.added, "a", indent: 1),
             line(.added, "", indent: 1),
             line(.added, "b", indent: 1),
         ]]
-        #expect(DiffFormat.inline.render(blocks).string == "+    a\n+\n+    b")
+        #expect(DiffFormat.inline.render(blocks).string == "+     a\n+\n+     b")
     }
 
-    @Test("an all-whitespace line gets no structural indent (content kept verbatim)")
+    @Test("an all-whitespace line gets no gutter or structural indent (content kept verbatim)")
     func whitespaceOnlyLineIsBlank() {
         let blocks = [[line(.unchanged, "    ", indent: 2)]]
-        // All-whitespace content => the marker is NOT followed by the level's
-        // indent (the `whitespace`, not `isEmpty`, blankness rule); the four
-        // content spaces themselves are kept. So: " " (marker) + "    " (content).
+        // All-whitespace content => the marker is NOT followed by the gutter or
+        // the level's indent (the `whitespace`, not `isEmpty`, blankness rule);
+        // the four content spaces themselves are kept. So: " " (marker) + "    "
+        // (content).
         #expect(DiffFormat.inline.render(blocks).string == "     ")
     }
 
     @Test("empty blocks contribute nothing and emit no separator")
     func emptyBlocksSkipped() {
         let blocks: [[DiffLine]] = [[], [line(.added, "x", indent: 0)], []]
-        #expect(DiffFormat.inline.render(blocks).string == "+x")
+        #expect(DiffFormat.inline.render(blocks).string == "+ x")
     }
 
     @Test("the result has no leading or trailing newline")
@@ -64,7 +65,7 @@ struct DiffFormatInlineTests {
         let rendered = DiffFormat.inline.render([[line(.unchanged, "a", indent: 0)]]).string
         #expect(!rendered.hasPrefix("\n"))
         #expect(!rendered.hasSuffix("\n"))
-        #expect(rendered == " a")
+        #expect(rendered == "  a")
     }
 
     @Test("an empty stream renders to nothing")
@@ -228,7 +229,7 @@ struct DiffFormatMarkdownTests {
         let blocks = [[line(.added, "var x: Int", indent: 0)]]
         let expected = """
         ```diff
-        +var x: Int
+        + var x: Int
         ```
         """
         #expect(DiffFormat.markdownFenced.render(blocks).string == expected)

--- a/Tests/SwiftInterfaceTests/DiffMarkingTests.swift
+++ b/Tests/SwiftInterfaceTests/DiffMarkingTests.swift
@@ -4,22 +4,22 @@ import Semantic
 
 @Suite("DiffMarking.markLines")
 struct DiffMarkingTests {
-    @Test("a single line gets one marker plus the level indent at column 0")
+    @Test("a single line gets one marker, the one-space gutter, and the level indent at column 0")
     func singleLine() {
-        #expect(DiffMarking.markLines("var x: Int", marker: .added, indentLevel: 1).string == "+    var x: Int")
-        #expect(DiffMarking.markLines("var x: Int", marker: .removed, indentLevel: 2).string == "-        var x: Int")
-        #expect(DiffMarking.markLines("struct Foo {", marker: .unchanged, indentLevel: 0).string == " struct Foo {")
+        #expect(DiffMarking.markLines("var x: Int", marker: .added, indentLevel: 1).string == "+     var x: Int")
+        #expect(DiffMarking.markLines("var x: Int", marker: .removed, indentLevel: 2).string == "-         var x: Int")
+        #expect(DiffMarking.markLines("struct Foo {", marker: .unchanged, indentLevel: 0).string == "  struct Foo {")
     }
 
     @Test("every line of a multi-line unit carries the marker")
     func multiLine() {
         let source: SemanticString = "var x: Int {\n    get\n}"
-        #expect(DiffMarking.markLines(source, marker: .added, indentLevel: 1).string == "+    var x: Int {\n+        get\n+    }")
+        #expect(DiffMarking.markLines(source, marker: .added, indentLevel: 1).string == "+     var x: Int {\n+         get\n+     }")
     }
 
-    @Test("a blank interior line carries only the marker, no trailing indent")
+    @Test("a blank interior line carries only the marker, no trailing indent or gutter")
     func blankInteriorLine() {
-        #expect(DiffMarking.markLines("a\n\nb", marker: .added, indentLevel: 1).string == "+    a\n+\n+    b")
+        #expect(DiffMarking.markLines("a\n\nb", marker: .added, indentLevel: 1).string == "+     a\n+\n+     b")
     }
 
     @Test("empty source produces no output (no stray marker)")
@@ -33,6 +33,6 @@ struct DiffMarkingTests {
         let marked = DiffMarking.markLines("a\nb", marker: .unchanged, indentLevel: 0).string
         #expect(!marked.hasPrefix("\n"))
         #expect(!marked.hasSuffix("\n"))
-        #expect(marked == " a\n b")
+        #expect(marked == "  a\n  b")
     }
 }


### PR DESCRIPTION
## Summary
- `feat(SwiftInterface)`: gutter-style inline/markdown diff so the +/- marker stays in column 0; nested diff fixtures with inline + unified outputs.
- `feat(testing)`: shared `TestActor` and macOS dyld cache paths for cross-suite reuse.
- `fix(SwiftPrinting)`: wrap `renderMember` body in `Rows(level:)` so per-member offset/vtable/address comments stay independent rows instead of fusing with the declaration.
- `test(SwiftInspection)`: simplify multi-payload enum defer block.
- `chore(swift-section)`: bump bundled version to `0.12.0-beta.5`.

## Test plan
- [ ] `swift package update && swift test --skip IntegrationTests`
- [ ] Manually verify `swift-section interface` output: per-member offset/vtable/address comments now render on their own rows (no fusion with the declaration line).
- [ ] Verify `swift-section diff` markdown / inline outputs still align with the gutter convention.
- [ ] `swift run swift-section --version` reports `0.12.0-beta.5`.