### PR TITLE
ci: parallelize test configurations, cache the SwiftPM build, force prebuilts

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -1,4 +1,4 @@
-name: macOS 
+name: macOS
 
 on:
   push:
@@ -17,6 +17,10 @@ jobs:
         # Adding an Intel runner would load a different arch slice and drift snapshots.
         os: [macos-26]
         xcode-version: ["26.4"]
+        # debug and release run as parallel jobs — sequentially they doubled
+        # the wall clock (14m + 21m cold). Release stays in the matrix on
+        # purpose: optimizer-sensitive pointer bugs only surface there.
+        configuration: [debug, release]
     env:
       MACHO_SWIFT_SECTION_SILENT_TEST: 1
       GH_TOKEN: ${{ github.token }}
@@ -80,20 +84,26 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: symboltests-derived-data-logs
+          name: symboltests-derived-data-logs-${{ matrix.configuration }}
           path: Tests/Projects/SymbolTests/DerivedData/Logs
           if-no-files-found: ignore
 
-      - name: Build and run tests in debug mode
-        run: |
-          swift test \
-            -c debug \
-            --build-path .build-test-debug \
-            --filter '\.(SymbolTestsCoreDumpSnapshotTests|SymbolTestsCoreInterfaceSnapshotTests|SymbolTestsCoreCoverageInvariantTests|STCoreE2ETests|STCoreTests|GenericSpecializationTests|MultiPayloadEnumTests|MetadataReaderDemanglingTests)(/|$)'
+      - name: Cache SwiftPM build directory
+        uses: actions/cache@v4
+        with:
+          path: .build-test-${{ matrix.configuration }}
+          # This step runs after `swift package update`, so the key hashes the
+          # post-update Package.resolved: a floated dependency bump rotates
+          # the key, and restore-keys falls back to the newest cache for the
+          # same configuration — an almost-warm build instead of a cold one.
+          key: spm-build-${{ matrix.os }}-${{ matrix.xcode-version }}-${{ matrix.configuration }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          restore-keys: |
+            spm-build-${{ matrix.os }}-${{ matrix.xcode-version }}-${{ matrix.configuration }}-
 
-      - name: Build and run tests in release mode
+      - name: Build and run tests (${{ matrix.configuration }})
         run: |
           swift test \
-            -c release \
-            --build-path .build-test-release \
+            -c ${{ matrix.configuration }} \
+            --enable-experimental-prebuilts \
+            --build-path .build-test-${{ matrix.configuration }} \
             --filter '\.(SymbolTestsCoreDumpSnapshotTests|SymbolTestsCoreInterfaceSnapshotTests|SymbolTestsCoreCoverageInvariantTests|STCoreE2ETests|STCoreTests|GenericSpecializationTests|MultiPayloadEnumTests|MetadataReaderDemanglingTests)(/|$)'


### PR DESCRIPTION
The macOS workflow ran debug and release sequentially on one runner (14m21s + 20m41s cold on the last main run), cached only the fixture DerivedData (a 24-second step), and its log shows swift-syntax compiled from source (182 compile units) — Xcode 26.4's toolchain did not engage SwiftPM prebuilts on its own.

Three changes, stacked:

1. **Parallel matrix jobs for debug/release** — wall clock drops to the slower leg. Release stays in the matrix deliberately: optimizer-sensitive pointer bugs only surface there. The failure-artifact name gains a configuration suffix so the two jobs cannot collide.
2. **`actions/cache` on the per-configuration `.build-test-*` directory** — keyed on the post-`swift package update` `Package.resolved` + `Package.swift`, with a same-configuration `restore-keys` fallback so a floated dependency bump still restores an almost-warm build. First run is cold by definition; the payoff starts with the second run.
3. **Explicit `--enable-experimental-prebuilts` on `swift test`** — default-on under the 26.5 toolchain but demonstrably not engaged under CI's 26.4; when no prebuilt artifact matches, SwiftPM silently falls back to source, so the flag is safe everywhere.

This PR's own run shows the cold-cache effect (parallelization + prebuilts); the first post-merge run on main exercises the warm cache.