### PR TITLE
ci: move the macOS test matrix to Xcode 26.6

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -16,7 +16,7 @@ jobs:
         # Apple Silicon runners only: MachOFileTests.preferredArchitecture == .arm64.
         # Adding an Intel runner would load a different arch slice and drift snapshots.
         os: [macos-26]
-        xcode-version: ["26.4"]
+        xcode-version: ["26.6"]
         # debug and release run as parallel jobs — sequentially they doubled
         # the wall clock (14m + 21m cold). Release stays in the matrix on
         # purpose: optimizer-sensitive pointer bugs only surface there.


### PR DESCRIPTION
Xcode 26.6 (17F113) is installed on the macos-26 runner image. The bump
also gives SwiftPM's swift-syntax prebuilts a newer toolchain: under
26.4 the explicitly-enabled flag never engaged (no published artifact
for that compiler — 194 swift-syntax compile units in the log), while
the 26.5+ toolchains default the feature on and are more likely to have
matching artifacts. Cache keys embed the Xcode version, so both the
fixture DerivedData and the SwiftPM build caches rotate cleanly; this
run also proves snapshot reproducibility under the 26.6 compiler.
