### PR TITLE
release: 0.15.2 — MachOKit as a range, not an exact pin

### DIFF
--- a/Changelogs/0.15.2.md
+++ b/Changelogs/0.15.2.md
@@ -1,0 +1,51 @@
+# 0.15.2
+
+A dependency-requirement release on top of `0.15.1`, closing the same deadlock that release opened up — in the one requirement it left behind. No API changes and no rendering or parsing behavior changes.
+
+1. **`MachOKit` is required as `0.52.101 ..< 0.53.0` instead of `exact: "0.52.100"`** — an exact requirement in a library deadlocks any consumer that also depends on MachOKit directly. `0.15.1` fixed this for MachOObjCSection and left MachOKit exact; RuntimeViewer hit it the moment it moved to `0.52.101`.
+2. **The lower bound moves to `0.52.101`**, picking up the ObjC header info lookup fix for dyld subcaches.
+3. **`MachOKitExtensions` moves to `from: "0.1.1"`** — bind resolution in legacy binaries that carry no chained fixups, and dyld cache image matches that are ranked rather than first-hit.
+4. **`swift-semantic-string` moves to `from: "0.3.0"`**, which is what `0.15.1`'s changelog already claimed while `Package.swift` still said `0.1.5`. The resolved version was `0.3.0` either way, because MachOObjCSection requires it; only the spelling here was stale.
+5. **Three retroactive conformances are spelled `@retroactive`** — `FileHandle` and `MemoryMappedFile` conforming to `MachONamespacing`, and `ObjCClass64` / `ObjCClass64.Layout` to `LocatableLayoutWrapper` / `LayoutProtocol`. Both the types and the protocols live in other modules, so the attribute is what the compiler asks for.
+6. **`Package.swift` no longer reads a `.package.env` file.** Local-dependency switching is environment variables only.
+
+Rendered output is byte-for-byte unchanged.
+
+## Highlights
+
+### The requirement `0.15.1` did not convert
+
+`0.15.1` made the case at length: two `exact:` requirements on one package have no intersection unless they name the same version, so a library that pins exactly deadlocks every consumer that also depends on that package directly. It converted MachOObjCSection to a range and left MachOKit as `exact: "0.52.100"`.
+
+RuntimeViewer depends on this package *and* on MachOKit directly. When it moved to `0.52.101` for the subcache fix, resolution stopped having a solution:
+
+```
+error: Failed to resolve dependencies Dependencies could not be resolved because
+'runtimeviewercore' depends on 'machoswiftsection' 0.15.1.
+'machoswiftsection' 0.15.1 cannot be used because 'machoswiftsection' 0.15.1
+depends on 'machokit' 0.52.100 and 'runtimeviewercore' depends on 'machokit' 0.52.101.
+```
+
+Same failure, same shape, one release later. Bumping the pinned version would only move the deadlock to the next MachOKit patch either side wants first, so the requirement itself becomes a range.
+
+The upper bound stops at the next minor rather than opening to `1.0.0`, for the reason `0.15.1` gave for MachOObjCSection: this line has removed public API within a minor before, and a wider bound would let a future release float this package onto an incompatible MachOKit.
+
+### What `0.52.101` carries
+
+One three-line fix, upstream `p-x9/MachOKit#310`: ObjC header info lookup resolved against the wrong subcache when reading a split dyld shared cache. Nothing in this package changes shape because of it.
+
+## Compatibility
+
+- No API additions, removals or renames. No snapshot `formatVersion` change.
+- Consumers that pinned `MachOKit` to `0.52.100` alongside this package can now move anywhere in `0.52.101 ..< 0.53.0`; that is the point of the release.
+- **Pinned dependencies** for this release — the first four lines differ from `0.15.1`:
+  - `MachOKit` → `0.52.101 ..< 0.53.0`.
+  - `MachOKitExtensions` → `from: "0.1.1"`.
+  - `swift-semantic-string` → `from: "0.3.0"`.
+  - `MachOObjCSection` → `0.8.104 ..< 0.9.0`, unchanged and for the reasons given in `0.15.1`.
+  - `swift-demangling` → `0.4.5 ..< 0.5.0`, unchanged and for the reasons given in `0.14.1`.
+
+## Requirements
+
+- Swift 6.2+
+- Xcode 26.0+ (CI validates the test matrix on Xcode 26.6 / macOS 26)

--- a/Package.swift
+++ b/Package.swift
@@ -5,33 +5,8 @@
 import CompilerPluginSupport
 import Foundation
 
-let localEnvironment: [String: String] = {
-    let localEnvironmentFilePath = URL(fileURLWithPath: #filePath)
-        .deletingLastPathComponent()
-        .appendingPathComponent(".package.env")
-        .path
-    guard FileManager.default.fileExists(atPath: localEnvironmentFilePath),
-          let contents = try? String(contentsOfFile: localEnvironmentFilePath, encoding: .utf8)
-    else {
-        return [:]
-    }
-    var environment: [String: String] = [:]
-    for line in contents.components(separatedBy: .newlines) {
-        let trimmedLine = line.trimmingCharacters(in: .whitespaces)
-        if trimmedLine.isEmpty || trimmedLine.hasPrefix("#") {
-            continue
-        }
-        let parts = trimmedLine.split(separator: "=", maxSplits: 1)
-        guard parts.count == 2 else { continue }
-        let key = parts[0].trimmingCharacters(in: .whitespaces)
-        let value = parts[1].trimmingCharacters(in: .whitespaces)
-        environment[key] = value
-    }
-    return environment
-}()
-
 func envEnable(_ key: String, default defaultValue: Bool = false) -> Bool {
-    let value = localEnvironment[key] ?? Context.environment[key]
+    let value = Context.environment[key]
     guard let value else {
         return defaultValue
     }
@@ -174,7 +149,15 @@ extension Package.Dependency {
         ),
         remote: .package(
             url: "https://github.com/MxIris-Reverse-Engineering/MachOKit.git",
-            exact: "0.52.100",
+            // A range rather than `exact:`, for the same reason as
+            // MachOObjCSection below. RuntimeViewer depends on this package and
+            // on MachOKit directly, so an exact requirement here deadlocks
+            // resolution the moment the app moves to a newer patch — which is
+            // exactly what `0.52.101` did. The lower bound is `0.52.101`
+            // because it fixes ObjC header info lookup in dyld subcaches; the
+            // upper bound stops at the next minor, where this line is free to
+            // break again.
+            "0.52.101" ..< "0.53.0",
         ),
     )
 }
@@ -238,7 +221,7 @@ extension Package.Dependency {
         ),
         remote: .package(
             url: "https://github.com/MxIris-Reverse-Engineering/swift-semantic-string",
-            from: "0.1.5",
+            from: "0.3.0",
         ),
     )
 
@@ -253,7 +236,7 @@ extension Package.Dependency {
         ),
         remote: .package(
             url: "https://github.com/MxIris-Reverse-Engineering/MachOKitExtensions",
-            from: "0.1.0",
+            from: "0.1.1",
         ),
     )
 }

--- a/Sources/MachOReading/Extensions/FileHandle+.swift
+++ b/Sources/MachOReading/Extensions/FileHandle+.swift
@@ -2,7 +2,7 @@ import Foundation
 import MachOKit
 import MachOKitExtensions
 
-extension FileHandle: MachONamespacing {}
+extension FileHandle: @retroactive MachONamespacing {}
 
 extension MachONamespace where Base: FileHandle {
     func readDataSequence<Element>(

--- a/Sources/MachOReading/Extensions/FileIO+.swift
+++ b/Sources/MachOReading/Extensions/FileIO+.swift
@@ -3,7 +3,7 @@ import FileIO
 import MachOKit
 import MachOKitExtensions
 
-extension MemoryMappedFile: MachONamespacing {}
+extension MemoryMappedFile: @retroactive MachONamespacing {}
 
 extension MachONamespace where Base: _FileIOProtocol {
     func readDataSequence<Element>(

--- a/Sources/SwiftInspection/ClassHierarchyDumper.swift
+++ b/Sources/SwiftInspection/ClassHierarchyDumper.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Demangling
 import MachOKit
+import MachOKitExtensions
 import MachOFoundation
 import MachOSwiftSection
 @_spi(Core) import MachOObjCSection
@@ -59,7 +60,7 @@ extension ObjCClass64: @retroactive Equatable {
     }
 }
 
-extension ObjCClass64: LocatableLayoutWrapper, Resolvable, @unchecked @retroactive Sendable {}
+extension ObjCClass64: @retroactive LocatableLayoutWrapper, Resolvable, @unchecked @retroactive Sendable {}
 
 extension ObjCClass64.Layout: @retroactive Equatable {
     public static func == (lhs: ObjCClass64.Layout, rhs: ObjCClass64.Layout) -> Bool {
@@ -71,7 +72,7 @@ extension ObjCClass64.Layout: @retroactive Equatable {
     }
 }
 
-extension ObjCClass64.Layout: LayoutProtocol, @unchecked @retroactive Sendable {}
+extension ObjCClass64.Layout: @retroactive LayoutProtocol, @unchecked @retroactive Sendable {}
 
 extension String {
     fileprivate var demangledString: String {

--- a/Sources/swift-section/Version.swift
+++ b/Sources/swift-section/Version.swift
@@ -2,5 +2,5 @@
 // When bumping: also add Changelogs/<value>.md, then tag the release with the same string.
 // Verified by .github/workflows/version-check.yml (PR) and .github/workflows/release.yml (tag).
 enum BundledVersion {
-    static let value = "0.15.1"
+    static let value = "0.15.2"
 }


### PR DESCRIPTION
Closes the deadlock `0.15.1` opened up, in the one requirement it left behind.

`0.15.1` made the case that an `exact:` requirement in a library has no solution for any consumer that also depends on that package directly, converted MachOObjCSection to a range, and left MachOKit as `exact: "0.52.100"`. RuntimeViewer hit the same wall one release later, the moment it moved to MachOKit `0.52.101` for the subcache ObjC header info fix:

```
error: Failed to resolve dependencies Dependencies could not be resolved because
'runtimeviewercore' depends on 'machoswiftsection' 0.15.1.
'machoswiftsection' 0.15.1 cannot be used because 'machoswiftsection' 0.15.1
depends on 'machokit' 0.52.100 and 'runtimeviewercore' depends on 'machokit' 0.52.101.
```

## What changes

- **`MachOKit` → `0.52.101 ..< 0.53.0`** instead of `exact: "0.52.100"`. The upper bound stops at the next minor for the reason given for MachOObjCSection: this line has removed public API within a minor before.
- **`MachOKitExtensions` → `from: "0.1.1"`** — bind resolution in legacy binaries with no chained fixups, and dyld cache image matches that are ranked rather than first-hit.
- **`swift-semantic-string` → `from: "0.3.0"`**, which `0.15.1`'s changelog already claimed while `Package.swift` still said `0.1.5`. The resolved version was `0.3.0` either way, because MachOObjCSection requires it; only the spelling here was stale.
- **Three retroactive conformances spelled `@retroactive`** — both the types and the protocols come from other modules, which is what the attribute is for. The conformances themselves are unchanged.
- **`Package.swift` no longer reads `.package.env`** — local-dependency switching is environment variables only, matching what RuntimeViewer already did on its side.

No API changes. Rendered output is byte-for-byte unchanged.

## Verification

Full suite, `--skip IntegrationTests` per the AGENTS.md convention: **1354 tests in 253 suites passed**, `swift test` exit code 0.